### PR TITLE
Change codecov version to v4

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build with Maven
         run: mvn clean install -U -B
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true # Optional: Specify if the CI build should fail when Codecov fails.


### PR DESCRIPTION
### Proposed changes in this pull request

- Updated the Github Action PR Builder to use codecov version 4 instead of 4.0.1.
- Solves the codecov token issue