### PR TITLE
Enrich user account lock event payload

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/builder/UserOperationEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/builder/UserOperationEventPayloadBuilder.java
@@ -33,7 +33,10 @@ public interface UserOperationEventPayloadBuilder {
     EventPayload buildUserDeleteEvent(EventData eventData) throws IdentityEventException;
 
     EventPayload buildUserUnlockAccountEvent(EventData eventData) throws IdentityEventException;
+
     EventPayload buildCredentialUpdateEvent(EventData eventData) throws IdentityEventException;
+
+    EventPayload buildUserLockAccountEvent(EventData eventData) throws IdentityEventException;
 
     /**
      * Get the event schema type.

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/constant/Constants.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/constant/Constants.java
@@ -92,6 +92,7 @@ public class Constants {
             public static final String POST_UPDATE_USER_CREDENTIAL = "user-operations.updateUserCredentials";
             public static final String SESSION_REVOKED_EVENT = "sessions.sessionRevoked";
             public static final String SESSION_CREATED_EVENT = "sessions.sessionCreated";
+            public static final String POST_LOCK_ACCOUNT_EVENT = "user-operations.lockUser";
 
             private WSO2() {
 
@@ -113,7 +114,7 @@ public class Constants {
             }
         }
 
-            private EventHandlerKey() {
+        private EventHandlerKey() {
 
         }
     }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandler.java
@@ -82,7 +82,8 @@ public class UserOperationEventHookHandler extends AbstractEventHandler {
                 IdentityEventConstants.Event.POST_DELETE_USER.equals(eventName) ||
                 IdentityEventConstants.Event.POST_ADD_NEW_PASSWORD.equals(eventName) ||
                 IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_SCIM.equals(eventName) ||
-                IdentityEventConstants.Event.POST_UNLOCK_ACCOUNT.equals(eventName);
+                IdentityEventConstants.Event.POST_UNLOCK_ACCOUNT.equals(eventName) ||
+                IdentityEventConstants.Event.POST_LOCK_ACCOUNT.equals(eventName);
     }
 
     @Override
@@ -142,8 +143,15 @@ public class UserOperationEventHookHandler extends AbstractEventHandler {
                 eventUri = eventConfigManager.getEventUri(Constants.EventHandlerKey.WSO2.POST_UPDATE_USER_CREDENTIAL);
                 SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils
                         .buildSecurityEventToken(eventPayload, eventUri);
-            EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
-        }
+                EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+            } else if (IdentityEventConstants.Event.POST_LOCK_ACCOUNT.equals(event.getEventName()) &&
+                    userOperationEventPublisherConfig.isPublishEnabled()) {
+                eventPayload = payloadBuilder.buildUserLockAccountEvent(eventData);
+                eventUri = eventConfigManager.getEventUri(Constants.EventHandlerKey.WSO2.POST_LOCK_ACCOUNT_EVENT);
+                SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils
+                        .buildSecurityEventToken(eventPayload, eventUri);
+                EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+            }
         } catch (IdentityEventException e) {
             log.debug("Error while retrieving event publisher configuration for tenant.", e);
         }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventConfigManager.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventConfigManager.java
@@ -196,6 +196,10 @@ public class EventConfigManager {
                 eventName.equals(IdentityEventConstants.Event.POST_UNLOCK_ACCOUNT))) {
             return true;
         }
+        if ((Constants.EventHandlerKey.WSO2.POST_LOCK_ACCOUNT_EVENT.equals(attribute.getKey()) &&
+                eventName.equals(IdentityEventConstants.Event.POST_LOCK_ACCOUNT))) {
+            return true;
+        }
         if ((Constants.EventHandlerKey.WSO2.POST_UPDATE_USER_CREDENTIAL.equals(attribute.getKey()) &&
                 (eventName.equals(IdentityEventConstants.Event.POST_ADD_NEW_PASSWORD) ||
                         eventName.equals(IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_SCIM)))) {

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2UserOperationEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2UserOperationEventPayloadBuilder.java
@@ -158,10 +158,10 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
         String userName =
                 String.valueOf(eventData.getEventParams().get(IdentityEventConstants.EventProperty.USER_NAME));
 
-        User unlockedUser = new User();
-        enrichUser(userStoreManager, userName, unlockedUser);
-        unlockedUser.setRef(
-                EventPayloadUtils.constructFullURLWithEndpoint(SCIM2_ENDPOINT) + "/" + unlockedUser.getId());
+        User user = new User();
+        enrichUser(userStoreManager, userName, user);
+        user.setRef(
+                EventPayloadUtils.constructFullURLWithEndpoint(SCIM2_ENDPOINT) + "/" + user.getId());
 
         Organization organization = new Organization(tenantId, tenantDomain);
         Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
@@ -172,7 +172,7 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
 
         return new WSO2UserAccountEventPayload.Builder()
                 .initiatorType(initiatorType)
-                .user(unlockedUser)
+                .user(user)
                 .organization(organization)
                 .userStore(userStore)
                 .build();

--- a/pom.xml
+++ b/pom.xml
@@ -438,7 +438,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.146</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.174</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
This PR include the user account lock event payload and the relevant unit tests.

This PR should be merged after the version bump of following PR in this repo.

- https://github.com/wso2/carbon-identity-framework/pull/6785

Product-is issue

- https://github.com/wso2/product-is/issues/24120