### PR TITLE
Send event channel uri to publish

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandler.java
@@ -136,7 +136,8 @@ public class CredentialEventHookHandler extends AbstractEventHandler {
                     eventPayload = payloadBuilder.buildCredentialUpdateEvent(eventData);
                     SecurityEventTokenPayload securityEventTokenPayload =
                             EventHookHandlerUtils.buildSecurityEventToken(eventPayload, eventUri);
-                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                            credentialChangeChannel.getUri());
                 }
             }
         } catch (Exception e) {

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandler.java
@@ -138,12 +138,14 @@ public class RegistrationEventHookHandler extends AbstractEventHandler {
                     eventPayload = payloadBuilder.buildRegistrationSuccessEvent(eventData);
                     SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils
                             .buildSecurityEventToken(eventPayload, eventUri);
-                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                            registrationChannel.getUri());
                 } else if (isUserRegistrationFailedFlow(event.getEventName()) && isTopicExists) {
                     eventPayload = payloadBuilder.buildRegistrationFailureEvent(eventData);
                     SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils
                             .buildSecurityEventToken(eventPayload, eventUri);
-                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                            registrationChannel.getUri());
                 }
             }
         } catch (Exception e) {

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandler.java
@@ -143,7 +143,8 @@ public class SessionEventHookHandler extends AbstractEventHandler {
 
                         SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils.
                                 buildSecurityEventToken(eventPayload, eventUri, subject);
-                        EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                        EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                                sessionChannel.getUri());
                     }
                 }
             }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandler.java
@@ -151,7 +151,8 @@ public class UserOperationEventHookHandler extends AbstractEventHandler {
                     eventPayload = payloadBuilder.buildUserGroupUpdateEvent(eventData);
                     SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils
                             .buildSecurityEventToken(eventPayload, eventUri);
-                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                            userOperationChannel.getUri());
                 } else if (IdentityEventConstants.Event.PRE_DELETE_USER_WITH_ID.equals(event.getEventName()) &&
                         isTopicExists) {
 
@@ -165,19 +166,22 @@ public class UserOperationEventHookHandler extends AbstractEventHandler {
                     eventPayload = payloadBuilder.buildUserDeleteEvent(eventData);
                     SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils
                             .buildSecurityEventToken(eventPayload, eventUri);
-                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                            userOperationChannel.getUri());
                 } else if (IdentityEventConstants.Event.POST_UNLOCK_ACCOUNT.equals(event.getEventName()) &&
                         isTopicExists) {
                     eventPayload = payloadBuilder.buildUserUnlockAccountEvent(eventData);
                     SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils
                             .buildSecurityEventToken(eventPayload, eventUri);
-                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                            userOperationChannel.getUri());
                 } else if (IdentityEventConstants.Event.POST_LOCK_ACCOUNT.equals(event.getEventName()) &&
                         isTopicExists) {
                     eventPayload = payloadBuilder.buildUserLockAccountEvent(eventData);
                     SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils
                             .buildSecurityEventToken(eventPayload, eventUri);
-                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                            userOperationChannel.getUri());
                 }
             }
         } catch (Exception e) {

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/VerificationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/VerificationEventHookHandler.java
@@ -145,7 +145,8 @@ public class VerificationEventHookHandler extends AbstractEventHandler {
 
                     SecurityEventTokenPayload securityEventTokenPayload = EventHookHandlerUtils.
                             buildSecurityEventToken(eventPayload, eventUri, subject);
-                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain, eventUri);
+                    EventHookHandlerUtils.publishEventPayload(securityEventTokenPayload, tenantDomain,
+                            verificationChannel.getUri());
 
                 }
             }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandlerTest.java
@@ -142,7 +142,7 @@ public class CredentialEventHookHandlerTest {
     @DataProvider(name = "eventDataProvider")
     public Object[][] eventDataProvider() {
 
-        return new Object[][]{
+        return new Object[][] {
                 {IdentityEventConstants.Event.POST_ADD_NEW_PASSWORD, SAMPLE_EVENT_KEY},
                 {IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_SCIM, SAMPLE_EVENT_KEY},
         };
@@ -156,8 +156,9 @@ public class CredentialEventHookHandlerTest {
         org.wso2.carbon.identity.webhook.metadata.api.model.Event channelEvent =
                 new org.wso2.carbon.identity.webhook.metadata.api.model.Event(eventName, "description",
                         expectedEventKey);
+        String channelUri = "credential/change/channel/uri";
         Channel channel =
-                new Channel("Credential Change Channel", "Credential Change Channel", "credential/change/channel/uri",
+                new Channel("Credential Change Channel", "Credential Change Channel", channelUri,
                         Collections.singletonList(channelEvent));
         EventProfile eventProfile = new EventProfile("WSO2", "uri", Collections.singletonList(channel));
         List<EventProfile> profiles = Collections.singletonList(eventProfile);
@@ -191,7 +192,7 @@ public class CredentialEventHookHandlerTest {
                 credentialEventHookHandler.handleEvent(event);
 
                 utilsMocked.verify(() -> EventHookHandlerUtils.publishEventPayload(tokenPayload,
-                        CARBON_SUPER, expectedEventKey), times(1));
+                        CARBON_SUPER, channelUri), times(1));
             }
         }
         IdentityContext.destroyCurrentContext();
@@ -261,7 +262,7 @@ public class CredentialEventHookHandlerTest {
     private Event createEventWithProperties(String eventName) {
 
         HashMap<String, Object> properties = new HashMap<>();
-        String[] addedUsers = new String[]{DOMAIN_QUALIFIED_ADDED_USER_NAME};
+        String[] addedUsers = new String[] {DOMAIN_QUALIFIED_ADDED_USER_NAME};
         properties.put(IdentityEventConstants.EventProperty.NEW_USERS, addedUsers);
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, CARBON_SUPER);
         return new Event(eventName, properties);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandlerTest.java
@@ -95,7 +95,6 @@ public class RegistrationEventHookHandlerTest {
             "https://schemas.identity.wso2.org/events/registration/event-type/registrationSuccess";
     private static final String REGISTRATION_FAILURE_EVENT_KEY =
             "https://schemas.identity.wso2.org/events/registration/event-type/registrationFailure";
-    private static final String SAMPLE_ATTRIBUTE_JSON = "{\"sendCredentials\":false,\"publishEnabled\":true}";
     private static final String DOMAIN_QUALIFIED_ADDED_USER_NAME = "PRIMARY/john";
     private static final String CARBON_SUPER = "carbon.super";
     private static final String ADMIN = "ADMIN";
@@ -157,7 +156,7 @@ public class RegistrationEventHookHandlerTest {
     @DataProvider(name = "eventDataProvider")
     public Object[][] eventDataProvider() {
 
-        return new Object[][]{
+        return new Object[][] {
                 {IdentityEventConstants.Event.POST_ADD_USER, SAMPLE_EVENT_KEY},
                 {IdentityEventConstants.Event.POST_SELF_SIGNUP_CONFIRM, SAMPLE_EVENT_KEY},
                 {IdentityEventConstants.Event.USER_REGISTRATION_FAILED, REGISTRATION_FAILURE_EVENT_KEY},
@@ -173,7 +172,8 @@ public class RegistrationEventHookHandlerTest {
         org.wso2.carbon.identity.webhook.metadata.api.model.Event channelEvent =
                 new org.wso2.carbon.identity.webhook.metadata.api.model.Event(eventName, "description",
                         expectedEventKey);
-        Channel channel = new Channel("Registration Channel", "Registration Channel", "registration/channel/uri",
+        String channelUri = "registration/channel/uri";
+        Channel channel = new Channel("Registration Channel", "Registration Channel", channelUri,
                 Collections.singletonList(channelEvent));
         EventProfile eventProfile = new EventProfile("WSO2", "uri", Collections.singletonList(channel));
         List<EventProfile> profiles = Collections.singletonList(eventProfile);
@@ -190,11 +190,9 @@ public class RegistrationEventHookHandlerTest {
                     .thenReturn(mockedEventPayload);
 
             try (MockedStatic<EventHookHandlerUtils> utilsMocked = mockStatic(EventHookHandlerUtils.class)) {
-                // Mock all static methods used in the handler
                 EventMetadata eventMetadata = mock(EventMetadata.class);
                 SecurityEventTokenPayload tokenPayload = mock(SecurityEventTokenPayload.class);
 
-                // Set up eventMetadata to match the channel and event name
                 when(eventMetadata.getChannel()).thenReturn("Registration Channel");
                 when(eventMetadata.getEvent()).thenReturn(eventName);
 
@@ -208,7 +206,7 @@ public class RegistrationEventHookHandlerTest {
                 registrationEventHookHandler.handleEvent(event);
 
                 utilsMocked.verify(() -> EventHookHandlerUtils.publishEventPayload(eq(tokenPayload),
-                        eq(CARBON_SUPER), eq(expectedEventKey)), times(1));
+                        eq(CARBON_SUPER), eq(channelUri)), times(1));
             }
         }
     }
@@ -225,7 +223,7 @@ public class RegistrationEventHookHandlerTest {
     private Event createEventWithProperties(String eventName) {
 
         HashMap<String, Object> properties = new HashMap<>();
-        String[] addedUsers = new String[]{DOMAIN_QUALIFIED_ADDED_USER_NAME};
+        String[] addedUsers = new String[] {DOMAIN_QUALIFIED_ADDED_USER_NAME};
         properties.put(IdentityEventConstants.EventProperty.NEW_USERS, addedUsers);
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, CARBON_SUPER);
         properties.put(IdentityEventConstants.EventProperty.INITIATOR_TYPE, ADMIN);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandlerTest.java
@@ -125,7 +125,7 @@ public class SessionEventHookHandlerTest {
     @DataProvider(name = "eventDataProvider")
     public Object[][] eventDataProvider() {
 
-        return new Object[][]{
+        return new Object[][] {
                 {IdentityEventConstants.EventName.USER_SESSION_TERMINATE.name(),
                         SAMPLE_EVENT_KEY_SESSION_REVOKED
                 },
@@ -158,7 +158,8 @@ public class SessionEventHookHandlerTest {
         org.wso2.carbon.identity.webhook.metadata.api.model.Event channelEvent =
                 new org.wso2.carbon.identity.webhook.metadata.api.model.Event(eventName, "description",
                         expectedEventKey);
-        Channel channel = new Channel("Session Channel", "Session Channel", "session/channel/uri",
+        String channelUri = "session/channel/uri";
+        Channel channel = new Channel("Session Channel", "Session Channel", channelUri,
                 Collections.singletonList(channelEvent));
         EventProfile eventProfile = new EventProfile("CAEP", "uri", Collections.singletonList(channel));
         List<EventProfile> profiles = Collections.singletonList(eventProfile);
@@ -181,26 +182,22 @@ public class SessionEventHookHandlerTest {
                     .thenReturn(mockedEventPayload);
 
             try (MockedStatic<EventHookHandlerUtils> utilsMocked = mockStatic(EventHookHandlerUtils.class)) {
-                // Mock all static methods used in the handler
                 EventData eventDataProvider = mock(EventData.class);
                 org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata eventMetadata =
                         mock(org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata.class);
                 SecurityEventTokenPayload tokenPayload = mock(SecurityEventTokenPayload.class);
 
-                // Mock AuthenticatedUser for tenant domain
                 org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser mockUser =
                         mock(org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser.class);
                 when(mockUser.getTenantDomain()).thenReturn(SAMPLE_TENANT_DOMAIN);
                 when(eventDataProvider.getAuthenticatedUser()).thenReturn(mockUser);
 
-                // Set up eventDataProvider to return the correct tenant domain (optional, for completeness)
                 when(eventDataProvider.getEventParams()).thenReturn(
                         new HashMap<String, Object>() {{
                             put(org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.TENANT_DOMAIN,
                                     SAMPLE_TENANT_DOMAIN);
                         }}
                 );
-                // Set up eventMetadata to match the channel and event name
                 when(eventMetadata.getChannel()).thenReturn("Session Channel");
                 when(eventMetadata.getEvent()).thenReturn(eventName);
 
@@ -217,7 +214,7 @@ public class SessionEventHookHandlerTest {
                 sessionEventHookHandler.handleEvent(event);
 
                 utilsMocked.verify(() -> EventHookHandlerUtils.publishEventPayload(eq(tokenPayload),
-                        eq(SAMPLE_TENANT_DOMAIN), eq(expectedEventKey)), times(1));
+                        eq(SAMPLE_TENANT_DOMAIN), eq(channelUri)), times(1));
             }
         }
     }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandlerTest.java
@@ -153,7 +153,8 @@ public class UserOperationEventHookHandlerTest {
         org.wso2.carbon.identity.webhook.metadata.api.model.Event channelEvent =
                 new org.wso2.carbon.identity.webhook.metadata.api.model.Event(eventName, "description",
                         expectedEventKey);
-        Channel channel = new Channel("User Operation Channel", "User Operation Channel", "user/operation/channel/uri",
+        String channelUri = "user/operation/channel/uri";
+        Channel channel = new Channel("User Operation Channel", "User Operation Channel", channelUri,
                 Collections.singletonList(channelEvent));
         EventProfile eventProfile = new EventProfile("WSO2", "uri", Collections.singletonList(channel));
         List<EventProfile> profiles = Collections.singletonList(eventProfile);
@@ -196,7 +197,7 @@ public class UserOperationEventHookHandlerTest {
                 userOperationEventHookHandler.handleEvent(event);
 
                 utilsMocked.verify(() -> EventHookHandlerUtils.publishEventPayload(eq(tokenPayload),
-                        eq(CARBON_SUPER), eq(expectedEventKey)), times(1));
+                        eq(CARBON_SUPER), eq(channelUri)), times(1));
             }
         }
     }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/VerificationEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/VerificationEventHookHandlerTest.java
@@ -156,7 +156,8 @@ public class VerificationEventHookHandlerTest {
         org.wso2.carbon.identity.webhook.metadata.api.model.Event channelEvent =
                 new org.wso2.carbon.identity.webhook.metadata.api.model.Event(eventName, "description",
                         expectedEventKey);
-        Channel channel = new Channel("Verification Channel", "Verification Channel", "verification/channel/uri",
+        String channelUri = "verification/channel/uri";
+        Channel channel = new Channel("Verification Channel", "Verification Channel", channelUri,
                 Collections.singletonList(channelEvent));
         EventProfile eventProfile = new EventProfile("CAEP", "uri", Collections.singletonList(channel));
         List<EventProfile> profiles = Collections.singletonList(eventProfile);
@@ -198,7 +199,7 @@ public class VerificationEventHookHandlerTest {
                 verificationEventHookHandler.handleEvent(event);
 
                 utilsMocked.verify(() -> EventHookHandlerUtils.publishEventPayload(eq(tokenPayload),
-                        eq(SAMPLE_TENANT_DOMAIN), eq(expectedEventKey)), times(1));
+                        eq(SAMPLE_TENANT_DOMAIN), eq(channelUri)), times(1));
             }
         }
     }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates the event handling logic across several classes to use channel-specific URIs when publishing event payloads instead of relying on a generic `eventUri`. It also includes corresponding updates in the test cases to ensure the new behavior is correctly validated.

### Event Handling Updates:
* [`CredentialEventHookHandler.java`](diffhunk://#diff-deaf1dd299a29da4f6559edd65715eab61547dd24a63d68f8cac4f3b19b53a83L139-R140): Modified the `publishEventPayload` method to use `credentialChangeChannel.getUri()` for credential update events.
* [`RegistrationEventHookHandler.java`](diffhunk://#diff-6775a58bbd20c2071a3901b29830badbe7f31a9fc1dfdd76f33e64dbd56a0b02L141-R148): Updated `publishEventPayload` calls to use `registrationChannel.getUri()` for both registration success and failure events.
* [`SessionEventHookHandler.java`](diffhunk://#diff-4571638571b75bee71408e6570f025bb14838f8e72bb57e9111a7280560b9a26L146-R147): Changed `publishEventPayload` to use `sessionChannel.getUri()` for session-related events.
* [`UserOperationEventHookHandler.java`](diffhunk://#diff-d8d81195782868e827e34ec8e30ac09ee4d4d09a5817f61a6cd443862eb206e4L154-R155): Updated `publishEventPayload` to use `userOperationChannel.getUri()` for user group updates, user deletion, account unlock, and account lock events. [[1]](diffhunk://#diff-d8d81195782868e827e34ec8e30ac09ee4d4d09a5817f61a6cd443862eb206e4L154-R155) [[2]](diffhunk://#diff-d8d81195782868e827e34ec8e30ac09ee4d4d09a5817f61a6cd443862eb206e4L168-R184)
* [`VerificationEventHookHandler.java`](diffhunk://#diff-5d450a2eb8deee6ac242ae3ac794a45e754ae5156fcd10190e8b1ac4618adc0fL148-R149): Modified `publishEventPayload` to use `verificationChannel.getUri()` for verification-related events.

### Test Case Updates:
* [`CredentialEventHookHandlerTest.java`](diffhunk://#diff-8fabe9b6b26265a4c9aa8ee992f17f0af9c68eceb8233e82b269ec05f1761bbaR159-R161): Added `channelUri` variable and updated the expected URI in `publishEventPayload` verification. [[1]](diffhunk://#diff-8fabe9b6b26265a4c9aa8ee992f17f0af9c68eceb8233e82b269ec05f1761bbaR159-R161) [[2]](diffhunk://#diff-8fabe9b6b26265a4c9aa8ee992f17f0af9c68eceb8233e82b269ec05f1761bbaL194-R195)
* [`RegistrationEventHookHandlerTest.java`](diffhunk://#diff-260e03010299338224c7bc1d78ed8be346423d2eb30c7d9f7d4dc1af1d4aa5efL176-R176): Introduced `channelUri` and updated `publishEventPayload` verification to use it. Removed redundant comments for better readability. [[1]](diffhunk://#diff-260e03010299338224c7bc1d78ed8be346423d2eb30c7d9f7d4dc1af1d4aa5efL176-R176) [[2]](diffhunk://#diff-260e03010299338224c7bc1d78ed8be346423d2eb30c7d9f7d4dc1af1d4aa5efL211-R209)
* [`SessionEventHookHandlerTest.java`](diffhunk://#diff-043c6d507f6873c1046c4d7fbe2c999eea0d795ea62208789a154c6627cfd032L161-R162): Added `channelUri` and updated `publishEventPayload` verification. Removed unnecessary comments for clarity. [[1]](diffhunk://#diff-043c6d507f6873c1046c4d7fbe2c999eea0d795ea62208789a154c6627cfd032L161-R162) [[2]](diffhunk://#diff-043c6d507f6873c1046c4d7fbe2c999eea0d795ea62208789a154c6627cfd032L220-R217)
* [`UserOperationEventHookHandlerTest.java`](diffhunk://#diff-2559b100d34d07262a0c342a473ff0a17fa19ae4a0b8fcb068b1c8d0000785ddL156-R157): Added `channelUri` and updated verification logic for `publishEventPayload`. [[1]](diffhunk://#diff-2559b100d34d07262a0c342a473ff0a17fa19ae4a0b8fcb068b1c8d0000785ddL156-R157) [[2]](diffhunk://#diff-2559b100d34d07262a0c342a473ff0a17fa19ae4a0b8fcb068b1c8d0000785ddL199-R200)
* [`VerificationEventHookHandlerTest.java`](diffhunk://#diff-402c0af9af3b26858ba00c2e9b30ea04d4102e06940d3a45e9050bcf8f600b5aL159-R160): Introduced `channelUri` and updated verification logic for `publishEventPayload`. [[1]](diffhunk://#diff-402c0af9af3b26858ba00c2e9b30ea04d4102e06940d3a45e9050bcf8f600b5aL159-R160) [[2]](diffhunk://#diff-402c0af9af3b26858ba00c2e9b30ea04d4102e06940d3a45e9050bcf8f600b5aL201-R202)