### PR TITLE
Add Console app type to bypass console login

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java
@@ -164,10 +164,9 @@ public class LoginEventHookHandler extends AbstractEventHandler {
                         .build();
 
                 String applicationNameInEvent = eventData.getAuthenticationContext().getServiceProviderName();
+                //TODO: Remove this once the system application type is introduced.
                 boolean isEventTriggeredForSystemApplication = StringUtils.isNotBlank(applicationNameInEvent)
-                        && EventHookHandlerDataHolder.getInstance().getApplicationManagementService()
-                        .getSystemApplications().stream()
-                        .anyMatch(systemApplication -> systemApplication.equals(applicationNameInEvent));
+                        && "Console".equals(applicationNameInEvent);
 
                 boolean publisherCanHandleEvent = EventHookHandlerDataHolder.getInstance().getEventPublisherService()
                         .canHandleEvent(eventContext);


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request includes a small change to the `LoginEventHookHandler` class to simplify the logic for determining if an event is triggered for a system application. The change replaces a call to check against a list of system applications with a direct comparison to the string `"Console"`. 

* [`components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java`](diffhunk://#diff-201d7cf4ab2807ba5ebbf08c7bb5be2f1e5fc651e74f0b429537d7b6967fe229R167-R169): Simplified the logic for identifying system applications by replacing a stream-based check with a direct string comparison to `"Console"`. A TODO comment was also added to indicate this is temporary until the system application type is introduced.
