### PR TITLE
Update the channels and events to uri

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/constants/Constants.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/constants/Constants.java
@@ -41,12 +41,12 @@ public class Constants {
      */
     public static class Channel {
 
-        public static final String LOGIN_CHANNEL = "Logins";
-        public static final String CREDENTIAL_CHANGE_CHANNEL = "Credential updates";
-        public static final String REGISTRATION_CHANNEL = "Registrations";
-        public static final String USER_OPERATION_CHANNEL = "User account management";
-        public static final String VERIFICATION_CHANNEL = "Verification Channel";
-        public static final String SESSION_CHANNEL = "Sessions";
+        public static final String LOGIN_CHANNEL = "https://schemas.identity.wso2.org/events/login";
+        public static final String CREDENTIAL_CHANGE_CHANNEL = "https://schemas.identity.wso2.org/events/user";
+        public static final String REGISTRATION_CHANNEL = "https://schemas.identity.wso2.org/events/registration";
+        public static final String USER_OPERATION_CHANNEL = "https://schemas.identity.wso2.org/events/credential";
+        public static final String VERIFICATION_CHANNEL = "https://schemas.identity.wso2.org/events/verification";
+        public static final String SESSION_CHANNEL = "https://schemas.identity.wso2.org/events/session";
     }
 
     /**
@@ -54,26 +54,26 @@ public class Constants {
      */
     public static class Event {
 
-        public static final String LOGIN_SUCCESS_EVENT = "Login success";
-        public static final String LOGIN_FAILURE_EVENT = "Login failed";
-        public static final String POST_UPDATE_USER_CREDENTIAL = "Credential updated";
-        public static final String POST_REGISTRATION_SUCCESS_EVENT = "Registration success";
-        public static final String POST_REGISTRATION_FAILED_EVENT = "Registration failed";
-        public static final String POST_USER_CREATED_EVENT = "User created";
-        public static final String POST_UPDATE_USER_LIST_OF_ROLE_EVENT = "Post Update User List of Role Event";
-        public static final String POST_DELETE_USER_EVENT = "User account deleted";
-        public static final String POST_UNLOCK_ACCOUNT_EVENT = "User account unlocked";
-        public static final String POST_LOCK_ACCOUNT_EVENT = "User account locked";
-        public static final String POST_USER_PROFILE_UPDATED_EVENT = "User profile updated";
-        public static final String POST_ACCOUNT_ENABLE_EVENT = "User account enabled";
-        public static final String POST_ACCOUNT_DISABLE_EVENT = "User account disabled";
-        public static final String SESSION_CREATED_EVENT = "Session established";
-        public static final String SESSION_REVOKED_EVENT = "Session(s) revoked";
-        public static final String SESSION_EXPIRED_EVENT = "Session Expired Event";
-        public static final String SESSION_UPDATED_EVENT = "Session Updated Event";
-        public static final String SESSION_EXTENDED_EVENT = "Session Extended Event";
-        public static final String SESSION_ESTABLISHED_EVENT = "Session Established Event";
-        public static final String SESSION_PRESENTED_EVENT = "Session Presented Event";
-        public static final String VERIFICATION_EVENT = "Verification Event";
+        public static final String LOGIN_SUCCESS_EVENT = "https://schemas.identity.wso2.org/events/login/event-type/loginSuccess";
+        public static final String LOGIN_FAILURE_EVENT = "https://schemas.identity.wso2.org/events/login/event-type/loginFailed";
+        public static final String POST_UPDATE_USER_CREDENTIAL = "https://schemas.identity.wso2.org/events/credential/event-type/credentialUpdated";
+        public static final String POST_REGISTRATION_SUCCESS_EVENT = "https://schemas.identity.wso2.org/events/registration/event-type/registrationSuccess";
+        public static final String POST_REGISTRATION_FAILED_EVENT = "https://schemas.identity.wso2.org/events/registration/event-type/registrationFailed";
+        public static final String POST_USER_CREATED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/userCreated";
+        public static final String POST_UPDATE_USER_LIST_OF_ROLE_EVENT = "https://schemas.identity.wso2.org/events/group/event-type/groupUpdated";
+        public static final String POST_DELETE_USER_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/userDeleted";
+        public static final String POST_UNLOCK_ACCOUNT_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/userAccountUnlocked";
+        public static final String POST_LOCK_ACCOUNT_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/userAccountLocked";
+        public static final String POST_USER_PROFILE_UPDATED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/userProfileUpdated";
+        public static final String POST_ACCOUNT_ENABLE_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/userEnabled";
+        public static final String POST_ACCOUNT_DISABLE_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/userDisabled";
+        public static final String SESSION_CREATED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/sessionEstablished";
+        public static final String SESSION_REVOKED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/sessionRevoked";
+        public static final String SESSION_EXPIRED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/sessionExpired";
+        public static final String SESSION_UPDATED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/sessionUpdated";
+        public static final String SESSION_EXTENDED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/sessionExtended";
+        public static final String SESSION_ESTABLISHED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/sessionEstablished";
+        public static final String SESSION_PRESENTED_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/sessionPresented";
+        public static final String VERIFICATION_EVENT = "https://schemas.identity.wso2.org/events/user/event-type/verification";
     }
 }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandler.java
@@ -134,7 +134,7 @@ public class CredentialEventHookHandler extends AbstractEventHandler {
                 List<Channel> channels = eventProfile.getChannels();
 
                 Channel credentialChangeChannel =
-                        channels.stream().filter(channel -> eventMetadata.getChannel().equals(channel.getName()))
+                        channels.stream().filter(channel -> eventMetadata.getChannel().equals(channel.getUri()))
                                 .findFirst().orElse(null);
                 if (credentialChangeChannel == null) {
                     log.debug("No channel found for credential change event profile: " + eventProfile.getProfile());
@@ -142,7 +142,7 @@ public class CredentialEventHookHandler extends AbstractEventHandler {
                 }
 
                 eventUri = credentialChangeChannel.getEvents().stream()
-                        .filter(channelEvent -> Objects.equals(eventMetadata.getEvent(), channelEvent.getEventName()))
+                        .filter(channelEvent -> Objects.equals(eventMetadata.getEvent(), channelEvent.getEventUri()))
                         .findFirst().map(org.wso2.carbon.identity.webhook.metadata.api.model.Event::getEventUri)
                         .orElse(null);
 

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java
@@ -141,7 +141,7 @@ public class LoginEventHookHandler extends AbstractEventHandler {
                 List<Channel> channels = eventProfile.getChannels();
                 // Get the channel URI for the channel with name "Login Channel"
                 Channel loginChannel = channels.stream()
-                        .filter(channel -> eventMetadata.getChannel().equals(channel.getName()))
+                        .filter(channel -> eventMetadata.getChannel().equals(channel.getUri()))
                         .findFirst()
                         .orElse(null);
                 if (loginChannel == null) {
@@ -151,7 +151,7 @@ public class LoginEventHookHandler extends AbstractEventHandler {
 
                 eventUri = loginChannel.getEvents().stream()
                         .filter(channelEvent -> Objects.equals(eventMetadata.getEvent(),
-                                channelEvent.getEventName()))
+                                channelEvent.getEventUri()))
                         .findFirst()
                         .map(org.wso2.carbon.identity.webhook.metadata.api.model.Event::getEventUri)
                         .orElse(null);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandler.java
@@ -132,7 +132,7 @@ public class RegistrationEventHookHandler extends AbstractEventHandler {
                 List<Channel> channels = eventProfile.getChannels();
                 // Get the channel URI for the channel with name "Registration Channel"
                 Channel registrationChannel = channels.stream()
-                        .filter(channel -> eventMetadata.getChannel().equals(channel.getName()))
+                        .filter(channel -> eventMetadata.getChannel().equals(channel.getUri()))
                         .findFirst()
                         .orElse(null);
                 if (registrationChannel == null) {
@@ -142,7 +142,7 @@ public class RegistrationEventHookHandler extends AbstractEventHandler {
 
                 eventUri = registrationChannel.getEvents().stream()
                         .filter(channelEvent -> Objects.equals(eventMetadata.getEvent(),
-                                channelEvent.getEventName()))
+                                channelEvent.getEventUri()))
                         .findFirst()
                         .map(org.wso2.carbon.identity.webhook.metadata.api.model.Event::getEventUri)
                         .orElse(null);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandler.java
@@ -95,7 +95,7 @@ public class SessionEventHookHandler extends AbstractEventHandler {
                 List<Channel> channels = eventProfile.getChannels();
                 // Get the channel URI for the channel with name "Session Channel"
                 Channel sessionChannel = channels.stream()
-                        .filter(channel -> eventMetadata.getChannel().equals(channel.getName()))
+                        .filter(channel -> eventMetadata.getChannel().equals(channel.getUri()))
                         .findFirst()
                         .orElse(null);
                 if (sessionChannel == null) {
@@ -105,7 +105,7 @@ public class SessionEventHookHandler extends AbstractEventHandler {
 
                 eventUri = sessionChannel.getEvents().stream()
                         .filter(channelEvent -> Objects.equals(eventMetadata.getEvent(),
-                                channelEvent.getEventName()))
+                                channelEvent.getEventUri()))
                         .findFirst()
                         .map(org.wso2.carbon.identity.webhook.metadata.api.model.Event::getEventUri)
                         .orElse(null);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandler.java
@@ -173,7 +173,7 @@ public class UserOperationEventHookHandler extends AbstractEventHandler {
                 List<Channel> channels = eventProfile.getChannels();
                 // Get the channel URI for the channel with name "User Operation Channel"
                 Channel userOperationChannel = channels.stream()
-                        .filter(channel -> eventMetadata.getChannel().equals(channel.getName()))
+                        .filter(channel -> eventMetadata.getChannel().equals(channel.getUri()))
                         .findFirst()
                         .orElse(null);
                 if (userOperationChannel == null) {
@@ -183,7 +183,7 @@ public class UserOperationEventHookHandler extends AbstractEventHandler {
 
                 eventUri = userOperationChannel.getEvents().stream()
                         .filter(channelEvent -> Objects.equals(eventMetadata.getEvent(),
-                                channelEvent.getEventName()))
+                                channelEvent.getEventUri()))
                         .findFirst()
                         .map(org.wso2.carbon.identity.webhook.metadata.api.model.Event::getEventUri)
                         .orElse(null);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/VerificationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/VerificationEventHookHandler.java
@@ -136,7 +136,7 @@ public class VerificationEventHookHandler extends AbstractEventHandler {
                 List<Channel> channels = eventProfile.getChannels();
                 // Get the channel URI for the channel with name "Verification Channel"
                 Channel verificationChannel = channels.stream()
-                        .filter(channel -> eventMetadata.getChannel().equals(channel.getName()))
+                        .filter(channel -> eventMetadata.getChannel().equals(channel.getUri()))
                         .findFirst()
                         .orElse(null);
                 if (verificationChannel == null) {
@@ -146,7 +146,7 @@ public class VerificationEventHookHandler extends AbstractEventHandler {
 
                 eventUri = verificationChannel.getEvents().stream()
                         .filter(channelEvent -> Objects.equals(eventMetadata.getEvent(),
-                                channelEvent.getEventName()))
+                                channelEvent.getEventUri()))
                         .findFirst()
                         .map(org.wso2.carbon.identity.webhook.metadata.api.model.Event::getEventUri)
                         .orElse(null);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandlerTest.java
@@ -181,8 +181,8 @@ public class CredentialEventHookHandlerTest {
             try (MockedStatic<EventHookHandlerUtils> utilsMocked = mockStatic(EventHookHandlerUtils.class)) {
                 org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata eventMetadata =
                         mock(org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata.class);
-                when(eventMetadata.getChannel()).thenReturn("Credential Change Channel");
-                when(eventMetadata.getEvent()).thenReturn(eventName);
+                when(eventMetadata.getChannel()).thenReturn(channelUri);
+                when(eventMetadata.getEvent()).thenReturn(expectedEventKey);
 
                 utilsMocked.when(() -> EventHookHandlerUtils.getEventProfileManagerByProfile(anyString(), anyString()))
                         .thenReturn(eventMetadata);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandlerTest.java
@@ -202,8 +202,8 @@ public class LoginEventHookHandlerTest {
                 // Mock login tenant domain and service provider name
 
                 EventMetadata eventMetadata = mock(EventMetadata.class);
-                when(eventMetadata.getChannel()).thenReturn("Login Channel");
-                when(eventMetadata.getEvent()).thenReturn(eventName);
+                when(eventMetadata.getChannel()).thenReturn("login/channel/uri");
+                when(eventMetadata.getEvent()).thenReturn(expectedEventKey);
 
                 SecurityEventTokenPayload tokenPayload = mock(SecurityEventTokenPayload.class);
 

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandlerTest.java
@@ -171,7 +171,7 @@ public class RegistrationEventHookHandlerTest {
         org.wso2.carbon.identity.webhook.metadata.api.model.Event channelEvent =
                 new org.wso2.carbon.identity.webhook.metadata.api.model.Event("Registration success", "description",
                         expectedEventKey);
-        String channelUri = "registration/channel/uri";
+        String channelUri = "https://schemas.identity.wso2.org/events/registration";
         Channel channel = new Channel("Registrations", "Registration Channel", channelUri,
                 Collections.singletonList(channelEvent));
         EventProfile eventProfile = new EventProfile("WSO2", "uri", Collections.singletonList(channel));
@@ -193,8 +193,8 @@ public class RegistrationEventHookHandlerTest {
                 EventMetadata eventMetadata = mock(EventMetadata.class);
                 SecurityEventTokenPayload tokenPayload = mock(SecurityEventTokenPayload.class);
 
-                when(eventMetadata.getChannel()).thenReturn("Registrations");
-                when(eventMetadata.getEvent()).thenReturn("Registration success");
+                when(eventMetadata.getChannel()).thenReturn(channelUri);
+                when(eventMetadata.getEvent()).thenReturn(expectedEventKey);
                 when(eventMetadata.getEventProfile()).thenReturn("WSO2");
 
                 // Mock getEventMetadata to return our eventMetadata

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandlerTest.java
@@ -201,8 +201,8 @@ public class SessionEventHookHandlerTest {
                                     SAMPLE_TENANT_DOMAIN);
                         }}
                 );
-                when(eventMetadata.getChannel()).thenReturn("Session Channel");
-                when(eventMetadata.getEvent()).thenReturn(eventName);
+                when(eventMetadata.getChannel()).thenReturn(channelUri);
+                when(eventMetadata.getEvent()).thenReturn(expectedEventKey);
 
                 utilsMocked.when(() -> EventHookHandlerUtils.buildEventDataProvider(any(Event.class)))
                         .thenReturn(eventDataProvider);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandlerTest.java
@@ -176,8 +176,8 @@ public class UserOperationEventHookHandlerTest {
                 // Mock EventMetadata to match the channel and event name
                 org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata eventMetadata =
                         mock(org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata.class);
-                when(eventMetadata.getChannel()).thenReturn("User Operation Channel");
-                when(eventMetadata.getEvent()).thenReturn(eventName);
+                when(eventMetadata.getChannel()).thenReturn(channelUri);
+                when(eventMetadata.getEvent()).thenReturn(expectedEventKey);
 
                 utilsMocked.when(() -> EventHookHandlerUtils.getEventProfileManagerByProfile(anyString(), anyString()))
                         .thenReturn(eventMetadata);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/VerificationEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/VerificationEventHookHandlerTest.java
@@ -182,8 +182,8 @@ public class VerificationEventHookHandlerTest {
                 // Mock EventMetadata to match the channel and event name
                 org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata eventMetadata =
                         mock(org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata.class);
-                when(eventMetadata.getChannel()).thenReturn("Verification Channel");
-                when(eventMetadata.getEvent()).thenReturn(eventName);
+                when(eventMetadata.getChannel()).thenReturn(channelUri);
+                when(eventMetadata.getEvent()).thenReturn(expectedEventKey);
 
                 utilsMocked.when(() -> EventHookHandlerUtils.getEventProfileManagerByProfile(anyString(), anyString()))
                         .thenReturn(eventMetadata);


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request refactors the event handling logic in the WSO2 Identity Server webhook module by replacing string-based event and channel identifiers with URI-based identifiers. The changes aim to standardize and improve the clarity of event and channel references. Below are the most important updates grouped by theme:

### Standardization of Event and Channel Identifiers

* Updated `Constants.java` to replace string-based channel and event identifiers with URI-based identifiers for consistency and better interoperability. For example, `LOGIN_CHANNEL` was changed from `"Logins"` to `"https://schemas.identity.wso2.org/events/login"`. Similarly, event types like `LOGIN_SUCCESS_EVENT` were updated to URIs such as `"https://schemas.identity.wso2.org/events/login/event-type/loginSuccess"`.

### Refactoring Event Handling Logic

* Modified `CredentialEventHookHandler.java` to use `channel.getUri()` and `channelEvent.getEventUri()` instead of `channel.getName()` and `channelEvent.getEventName()` when filtering channels and events. This ensures compatibility with the new URI-based identifiers.

* Updated `LoginEventHookHandler.java` to replace string-based comparisons (`channel.getName()` and `channelEvent.getEventName()`) with URI-based comparisons (`channel.getUri()` and `channelEvent.getEventUri()`) for login-related events. [[1]](diffhunk://#diff-201d7cf4ab2807ba5ebbf08c7bb5be2f1e5fc651e74f0b429537d7b6967fe229L144-R144) [[2]](diffhunk://#diff-201d7cf4ab2807ba5ebbf08c7bb5be2f1e5fc651e74f0b429537d7b6967fe229L154-R154)

* Refactored `RegistrationEventHookHandler.java`, `SessionEventHookHandler.java`, `UserOperationEventHookHandler.java`, and `VerificationEventHookHandler.java` to adopt URI-based filtering for channels and events, aligning them with the updated event and channel schema. [[1]](diffhunk://#diff-6775a58bbd20c2071a3901b29830badbe7f31a9fc1dfdd76f33e64dbd56a0b02L135-R135) [[2]](diffhunk://#diff-6775a58bbd20c2071a3901b29830badbe7f31a9fc1dfdd76f33e64dbd56a0b02L145-R145) [[3]](diffhunk://#diff-4571638571b75bee71408e6570f025bb14838f8e72bb57e9111a7280560b9a26L98-R98) [[4]](diffhunk://#diff-4571638571b75bee71408e6570f025bb14838f8e72bb57e9111a7280560b9a26L108-R108) [[5]](diffhunk://#diff-d8d81195782868e827e34ec8e30ac09ee4d4d09a5817f61a6cd443862eb206e4L176-R176) [[6]](diffhunk://#diff-d8d81195782868e827e34ec8e30ac09ee4d4d09a5817f61a6cd443862eb206e4L186-R186) [[7]](diffhunk://#diff-5d450a2eb8deee6ac242ae3ac794a45e754ae5156fcd10190e8b1ac4618adc0fL139-R139) [[8]](diffhunk://#diff-5d450a2eb8deee6ac242ae3ac794a45e754ae5156fcd10190e8b1ac4618adc0fL149-R149)
