### PR TITLE
bug fixed

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/constants/Constants.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/constants/Constants.java
@@ -42,9 +42,9 @@ public class Constants {
     public static class Channel {
 
         public static final String LOGIN_CHANNEL = "https://schemas.identity.wso2.org/events/login";
-        public static final String CREDENTIAL_CHANGE_CHANNEL = "https://schemas.identity.wso2.org/events/user";
+        public static final String CREDENTIAL_CHANGE_CHANNEL = "https://schemas.identity.wso2.org/events/credential";
         public static final String REGISTRATION_CHANNEL = "https://schemas.identity.wso2.org/events/registration";
-        public static final String USER_OPERATION_CHANNEL = "https://schemas.identity.wso2.org/events/credential";
+        public static final String USER_OPERATION_CHANNEL = "https://schemas.identity.wso2.org/events/user";
         public static final String VERIFICATION_CHANNEL = "https://schemas.identity.wso2.org/events/verification";
         public static final String SESSION_CHANNEL = "https://schemas.identity.wso2.org/events/session";
     }


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates the event channel URLs in the `Channel` class within the `Constants.java` file to ensure they align with the correct event types.

Event channel URL updates:

* Updated `CREDENTIAL_CHANGE_CHANNEL` URL from `https://schemas.identity.wso2.org/events/user` to `https://schemas.identity.wso2.org/events/credential` for accuracy.
* Updated `USER_OPERATION_CHANNEL` URL from `https://schemas.identity.wso2.org/events/credential` to `https://schemas.identity.wso2.org/events/user` to correct the mapping.