### PR TITLE
Remove stale file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.283</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.303-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
@@ -518,11 +518,6 @@
         <com.fasterxml.jackson.databind.version>2.14.1</com.fasterxml.jackson.databind.version>
         <servlet-api.version>2.5</servlet-api.version>
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
-
-        <!--Web Sub Hub Adapter dependency versions-->
-        <org.wso2.identity.event.publishers.version>1.0.11</org.wso2.identity.event.publishers.version>
-        <org.wso2.identity.event.publishers.version.range>[1.0.0,2.0.0)
-        </org.wso2.identity.event.publishers.version.range>
 
         <!--Check style dependency versions-->
         <maven.checkstyleplugin.version>2.17</maven.checkstyleplugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.303-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.305</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates dependency versions in the `pom.xml` file to align with the latest development requirements and removes unused dependency version entries.

### Dependency Updates:
* Updated the `carbon.identity.framework.version` to `7.8.303-SNAPSHOT` from `7.8.283` to incorporate the latest framework changes. (`pom.xml`, [pom.xmlL460-R460](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L460-R460))

### Cleanup:
* Removed unused dependency version entries for `org.wso2.identity.event.publishers.version` and its version range, as they are no longer required. (`pom.xml`, [pom.xmlL522-L526](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L522-L526))
