### PR TITLE
Improve session established event.

### DIFF
--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2SessionCreatedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2SessionCreatedEventPayload.java
@@ -20,22 +20,17 @@ package org.wso2.identity.webhook.wso2.event.handler.internal.model;
 
 import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.Application;
 import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.Organization;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.Session;
 import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.User;
 import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.UserStore;
 
 public class WSO2SessionCreatedEventPayload extends WSO2BaseEventPayload {
 
-    private String sessionId;
-    private String currentAcr;
+    private Session session;
 
-    public String getSessionId() {
+    public Session getSession() {
 
-        return sessionId;
-    }
-
-    public String getCurrentAcr() {
-
-        return currentAcr;
+        return session;
     }
 
     private WSO2SessionCreatedEventPayload(Builder builder) {
@@ -45,8 +40,7 @@ public class WSO2SessionCreatedEventPayload extends WSO2BaseEventPayload {
         this.organization = builder.organization;
         this.userStore = builder.userStore;
         this.application = builder.application;
-        this.sessionId = builder.sessionId;
-        this.currentAcr = builder.currentAcr;
+        this.session = builder.session;
     }
 
     private WSO2SessionCreatedEventPayload() {
@@ -55,25 +49,12 @@ public class WSO2SessionCreatedEventPayload extends WSO2BaseEventPayload {
 
     public static class Builder {
 
-        private String sessionId;
-        private String currentAcr;
         private User user;
         private Organization tenant;
         private Organization organization;
         private UserStore userStore;
         private Application application;
-
-        public Builder sessionId(String sessionId) {
-
-            this.sessionId = sessionId;
-            return this;
-        }
-
-        public Builder currentAcr(String currentAcr) {
-
-            this.currentAcr = currentAcr;
-            return this;
-        }
+        private Session session;
 
         public Builder user(User user) {
 
@@ -102,6 +83,12 @@ public class WSO2SessionCreatedEventPayload extends WSO2BaseEventPayload {
         public Builder application(Application application) {
 
             this.application = application;
+            return this;
+        }
+
+        public Builder session(Session session) {
+
+            this.session = session;
             return this;
         }
 

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/Session.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/Session.java
@@ -18,6 +18,7 @@
 
 package org.wso2.identity.webhook.wso2.event.handler.internal.model.common;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -25,22 +26,57 @@ import java.util.List;
  */
 public class Session {
 
-    private final String sessionId;
+    private final String id;
+    private final Date loginTime;
     private final List<Application> applications;
 
-    public Session(String sessionId, List<Application> applications) {
+    private Session(Builder builder) {
 
-        this.sessionId = sessionId;
-        this.applications = applications;
+        this.id = builder.id;
+        this.loginTime = builder.loginTime;
+        this.applications = builder.applications;
     }
 
-    public String getSessionId() {
+    public String getId() {
+        return id;
+    }
 
-        return sessionId;
+    public Date getLoginTime() {
+
+        return loginTime;
     }
 
     public List<Application> getApplications() {
-
         return applications;
+    }
+
+    public static class Builder {
+
+        private String id;
+        private Date loginTime;
+        private List<Application> applications;
+
+        public Builder id(String id) {
+
+            this.id = id;
+            return this;
+        }
+
+        public Builder loginTime(Date loginTime) {
+
+            this.loginTime = loginTime;
+            return this;
+        }
+
+        public Builder applications(List<Application> applications) {
+
+            this.applications = applications;
+            return this;
+        }
+
+        public Session build() {
+
+            return new Session(this);
+        }
     }
 }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2SessionEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2SessionEventPayloadBuilderTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
@@ -102,6 +103,9 @@ public class WSO2SessionEventPayloadBuilderTest {
     @Mock
     private ClaimMetadataManagementService claimMetadataManagementService;
 
+    @Mock
+    private UserSessionManagementService userSessionManagementService;
+
     private MockedStatic<FrameworkUtils> frameworkUtilsMockedStatic;
 
     @BeforeClass
@@ -110,6 +114,7 @@ public class WSO2SessionEventPayloadBuilderTest {
         MockitoAnnotations.openMocks(this);
         WSO2EventHookHandlerDataHolder.getInstance().setOrganizationManager(mockOrganizationManager);
         WSO2EventHookHandlerDataHolder.getInstance().setClaimMetadataManagementService(claimMetadataManagementService);
+        WSO2EventHookHandlerDataHolder.getInstance().setUserSessionManagementService(userSessionManagementService);
 
         mockAuthenticationContext = createMockAuthenticationContext();
         mockAuthenticatedUser = createMockAuthenticatedUser();


### PR DESCRIPTION
### Proposed changes in this pull request

Related to https://github.com/wso2/product-is/issues/24743

This PR improves the session payload of the **session established event** adding a `session` object to the payload.

```json
{
  iss: 'https://localhost:9443',
  jti: '6809486d-a593-44b8-b181-be61093a27f4',
  iat: 1753155569892,
  rci: '07367cd7-25d2-4190-bfea-204885cc2178',
  events: {
    'https://schemas.identity.wso2.org/events/session/event-type/sessionEstablished': {
      user: {
        id: 'ffc27c4d-1b43-410d-9bf2-954bc8e5bb72',
        claims: [ { uri: 'http://wso2.org/claims/username', value: 'emily' } ],
        ref: 'https://localhost:9443/scim2/Users/ffc27c4d-1b43-410d-9bf2-954bc8e5bb72'
      },
      tenant: { id: '-1234', name: 'carbon.super' },
      userStore: { id: 'UFJJTUFSWQ==', name: 'PRIMARY' },
      application: {
        id: '0fb769d7-ad1e-4863-bb55-fcd1079acf0d',
        name: 'My Account'
      },
      session: {
        id: '3786b19b9bc72240b16a92f5262d46cd56c5df670f51b632c2d2625ef186be04',
        loginTime: 1753155569876,
        applications: [ { id: '1', name: 'My Account' } ]
      }
    }
  }
}
```