### PR TITLE
Onboarding new flow definitions

### DIFF
--- a/components/org.wso2.identity.webhook.caep.event.handler/src/test/java/org/wso2/identity/webhook/caep/event/handler/CAEPSessionEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.caep.event.handler/src/test/java/org/wso2/identity/webhook/caep/event/handler/CAEPSessionEventPayloadBuilderTest.java
@@ -111,13 +111,13 @@ public class CAEPSessionEventPayloadBuilderTest {
     public Object[][] sessionTerminationDataProvider() {
 
         return new Object[][]{
-                {new Flow.Builder().name(Flow.Name.ACCOUNT_DISABLE)
+                {new Flow.Builder().name(Flow.Name.USER_ACCOUNT_DISABLE)
                         .initiatingPersona(Flow.InitiatingPersona.ADMIN).build()},
-                {new Flow.Builder().name(Flow.Name.ACCOUNT_LOCK)
+                {new Flow.Builder().name(Flow.Name.USER_ACCOUNT_LOCK)
                         .initiatingPersona(Flow.InitiatingPersona.SYSTEM).build()},
                 {new Flow.Builder().name(Flow.Name.LOGOUT)
                         .initiatingPersona(Flow.InitiatingPersona.APPLICATION).build()},
-                {new Flow.Builder().name(Flow.Name.USER_DELETE)
+                {new Flow.Builder().name(Flow.Name.USER_ACCOUNT_DELETE)
                         .initiatingPersona(Flow.InitiatingPersona.ADMIN).build()},
                 {new Flow.Builder().name(Flow.Name.SESSION_REVOKE)
                         .initiatingPersona(Flow.InitiatingPersona.USER).build()},

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandler.java
@@ -191,7 +191,7 @@ public class CredentialEventHookHandler extends AbstractEventHandler {
             Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
             Flow.Name flowName = (flow != null) ? flow.getName() : null;
 
-            return Flow.Name.PASSWORD_RESET.equals(flowName);
+            return Flow.Name.CREDENTIAL_RESET.equals(flowName);
         }
 
         return IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_SCIM.equals(eventName);

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandler.java
@@ -199,7 +199,7 @@ public class RegistrationEventHookHandler extends AbstractEventHandler {
                 (IdentityEventConstants.Event.USER_REGISTRATION_SUCCESS.equals(eventName)  ||
                         IdentityEventConstants.Event.POST_SELF_SIGNUP_CONFIRM.equals(eventName) ||
                         (IdentityEventConstants.Event.POST_ADD_NEW_PASSWORD.equals(eventName) &&
-                                Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD.equals(flowName)));
+                                Flow.Name.INVITE.equals(flowName)));
     }
 
     private boolean isUserRegistrationFailedFlow(String eventName) {

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandlerTest.java
@@ -107,9 +107,10 @@ public class CredentialEventHookHandlerTest {
         setupDataHolderMocks();
         setupPayloadBuilderMocks();
         setupUtilities();
-        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.PASSWORD_RESET)
+        IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.CredentialFlowBuilder()
+                .name(Flow.Name.CREDENTIAL_RESET)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
+                .credentialType(Flow.CredentialType.PASSWORD)
                 .build());
     }
 

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandlerTest.java
@@ -109,7 +109,7 @@ public class RegistrationEventHookHandlerTest {
         setupPayloadBuilderMocks();
         setupUtilities();
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.USER_REGISTRATION)
+                .name(Flow.Name.REGISTER)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
     }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2CredentialEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2CredentialEventPayloadBuilder.java
@@ -85,9 +85,9 @@ public class WSO2CredentialEventPayloadBuilder implements CredentialEventPayload
         switch (name) {
             case PROFILE_UPDATE:
                 return PasswordUpdateAction.UPDATE;
-            case PASSWORD_RESET:
+            case CREDENTIAL_RESET:
                 return PasswordUpdateAction.RESET;
-            case USER_REGISTRATION_INVITE_WITH_PASSWORD:
+            case INVITE:
                 return PasswordUpdateAction.INVITE;
             default: {
                 log.warn(name + " is not a valid password update action.");

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RegistrationEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RegistrationEventPayloadBuilder.java
@@ -41,7 +41,6 @@ import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.UserSt
 import org.wso2.identity.webhook.wso2.event.handler.internal.util.WSO2PayloadUtils;
 
 import java.util.Map;
-import java.util.Optional;
 
 public class WSO2RegistrationEventPayloadBuilder implements RegistrationEventPayloadBuilder {
 
@@ -81,9 +80,7 @@ public class WSO2RegistrationEventPayloadBuilder implements RegistrationEventPay
         String action = null;
         if (flow != null) {
             initiatorType = flow.getInitiatingPersona().name();
-            action = Optional.ofNullable(resolveAction(flow.getName()))
-                    .map(Enum::name)
-                    .orElse(null);
+            action = flow.getName().name();
         }
 
         return new WSO2RegistrationSuccessEventPayload.Builder()
@@ -136,9 +133,7 @@ public class WSO2RegistrationEventPayloadBuilder implements RegistrationEventPay
         String action = null;
         if (flow != null) {
             initiatorType = flow.getInitiatingPersona().name();
-            action = Optional.ofNullable(resolveAction(flow.getName()))
-                    .map(Enum::name)
-                    .orElse(null);
+            action = flow.getName().name();
         }
 
         String errorMessage = String.valueOf(properties.get(IdentityEventConstants.EventProperty.ERROR_MESSAGE));
@@ -167,30 +162,4 @@ public class WSO2RegistrationEventPayloadBuilder implements RegistrationEventPay
                 .reason(reason)
                 .build();
     }
-
-    private RegistrationAction resolveAction(Flow.Name name) {
-
-        if (name == null) {
-            return null;
-        }
-
-        switch (name) {
-            case USER_REGISTRATION:
-                return RegistrationAction.REGISTER;
-            case USER_REGISTRATION_INVITE_WITH_PASSWORD:
-            case INVITED_USER_REGISTRATION:
-                return RegistrationAction.INVITE;
-            case JIT_PROVISION:
-                return RegistrationAction.JUST_IN_TIME;
-            default: {
-                log.warn(name + " is not a valid registration action.");
-                return null;
-            }
-        }
-    }
-
-    public enum RegistrationAction {
-        REGISTER, INVITE, JUST_IN_TIME
-    }
-
 }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2UserOperationEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2UserOperationEventPayloadBuilder.java
@@ -269,9 +269,7 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
         String action = null;
         if (flow != null) {
             initiatorType = flow.getInitiatingPersona().name();
-            action = Optional.ofNullable(resolveAction(flow.getName()))
-                    .map(Enum::name)
-                    .orElse(null);
+            action = flow.getName().name();
         }
 
         return new WSO2UserAccountEventPayload.Builder()
@@ -445,15 +443,13 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
         }
 
         switch (name) {
-            case PROFILE_UPDATE:
-                return UserOperationAction.UPDATE;
-            case USER_REGISTRATION_INVITE_WITH_PASSWORD:
+            case INVITE:
             case INVITED_USER_REGISTRATION:
                 return UserOperationAction.INVITE;
-            case USER_REGISTRATION:
+            case REGISTER:
                 return UserOperationAction.REGISTER;
-            case JIT_PROVISION:
-                return UserOperationAction.JUST_IN_TIME;
+            case JUST_IN_TIME_PROVISION:
+                return UserOperationAction.JUST_IN_TIME_PROVISION;
             default: {
                 return null;
             }
@@ -461,6 +457,6 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
     }
 
     public enum UserOperationAction {
-        INVITE, UPDATE, REGISTER, JUST_IN_TIME
+        INVITE, REGISTER, JUST_IN_TIME_PROVISION
     }
 }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/util/WSO2PayloadUtils.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/util/WSO2PayloadUtils.java
@@ -392,7 +392,7 @@ public class WSO2PayloadUtils {
             Flow flow = IdentityContext.getThreadLocalIdentityContext().getFlow();
             Flow.Name flowName = (flow != null) ? flow.getName() : null;
 
-            return Flow.Name.PASSWORD_RESET.equals(flowName);
+            return Flow.Name.CREDENTIAL_RESET.equals(flowName);
         }
 
         return IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL_BY_SCIM.equals(eventName);

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2CredentialEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2CredentialEventPayloadBuilderTest.java
@@ -60,8 +60,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
+import static org.wso2.carbon.identity.core.context.model.Flow.Name.CREDENTIAL_RESET;
 import static org.wso2.carbon.identity.core.context.model.Flow.Name.GROUP_UPDATE;
-import static org.wso2.carbon.identity.core.context.model.Flow.Name.PASSWORD_RESET;
 import static org.wso2.carbon.identity.core.context.model.Flow.Name.PROFILE_UPDATE;
 import static org.wso2.identity.webhook.common.event.handler.internal.constant.Constants.PRE_DELETE_USER_ID;
 import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.SCIM2_USERS_ENDPOINT;
@@ -150,7 +150,7 @@ public class WSO2CredentialEventPayloadBuilderTest {
 
         return new Object[][]{
                 {PROFILE_UPDATE},
-                {PASSWORD_RESET},
+                {CREDENTIAL_RESET},
                 {GROUP_UPDATE},
                 {null}
         };
@@ -178,10 +178,18 @@ public class WSO2CredentialEventPayloadBuilderTest {
         }
 
         if (flowName != null) {
-            IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                    .name(flowName)
-                    .initiatingPersona(Flow.InitiatingPersona.ADMIN)
-                    .build());
+            if (CREDENTIAL_RESET.equals(flowName)) {
+                IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.CredentialFlowBuilder()
+                        .name(flowName)
+                        .initiatingPersona(Flow.InitiatingPersona.ADMIN)
+                        .credentialType(Flow.CredentialType.PASSWORD)
+                        .build());
+            } else {
+                IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
+                        .name(flowName)
+                        .initiatingPersona(Flow.InitiatingPersona.ADMIN)
+                        .build());
+            }
         }
 
         EventPayload eventPayload = payloadBuilder.buildCredentialUpdateEvent(mockEventData);
@@ -212,7 +220,7 @@ public class WSO2CredentialEventPayloadBuilderTest {
             assertEquals(userCredentialUpdateEventPayload.getAction(),
                     WSO2CredentialEventPayloadBuilder.PasswordUpdateAction.UPDATE.name());
             assertEquals(userCredentialUpdateEventPayload.getInitiatorType(), Flow.InitiatingPersona.ADMIN.name());
-        } else if (flowName.equals(PASSWORD_RESET)) {
+        } else if (flowName.equals(CREDENTIAL_RESET)) {
             assertNotNull(userCredentialUpdateEventPayload.getAction());
             assertEquals(userCredentialUpdateEventPayload.getAction(),
                     WSO2CredentialEventPayloadBuilder.PasswordUpdateAction.RESET.name());

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RegistrationEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RegistrationEventPayloadBuilderTest.java
@@ -151,7 +151,7 @@ public class WSO2RegistrationEventPayloadBuilderTest {
         when(mockEventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
 
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.USER_REGISTRATION)
+                .name(Flow.Name.REGISTER)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
 
@@ -166,8 +166,7 @@ public class WSO2RegistrationEventPayloadBuilderTest {
         assertEquals(userAccountEventPayload.getUser().getRef(),
                 constructFullURLWithEndpoint(SCIM2_USERS_ENDPOINT) + "/" + TEST_USER_ID);
         assertNotNull(userAccountEventPayload.getAction());
-        assertEquals(userAccountEventPayload.getAction(),
-                WSO2RegistrationEventPayloadBuilder.RegistrationAction.REGISTER.name());
+        assertEquals(userAccountEventPayload.getAction(), Flow.Name.REGISTER.name());
         assertNotNull(userAccountEventPayload.getUser().getClaims());
         assertEquals(userAccountEventPayload.getUser().getClaims().size(), 3);
 
@@ -230,7 +229,7 @@ public class WSO2RegistrationEventPayloadBuilderTest {
         when(mockEventData.getEventParams()).thenReturn(params);
 
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.USER_REGISTRATION)
+                .name(Flow.Name.REGISTER)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
 
@@ -245,8 +244,7 @@ public class WSO2RegistrationEventPayloadBuilderTest {
         assertEquals(userRegistrationFailurePayload.getUser().getRef(),
                 constructFullURLWithEndpoint(SCIM2_USERS_ENDPOINT) + "/" + TEST_USER_ID);
         assertNotNull(userRegistrationFailurePayload.getAction());
-        assertEquals(userRegistrationFailurePayload.getAction(),
-                WSO2RegistrationEventPayloadBuilder.RegistrationAction.REGISTER.name());
+        assertEquals(userRegistrationFailurePayload.getAction(), Flow.Name.REGISTER.name());
 
         assertNotNull(userRegistrationFailurePayload.getReason());
         assertNotNull(userRegistrationFailurePayload.getReason().getDescription());

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2UserOperationEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2UserOperationEventPayloadBuilderTest.java
@@ -242,7 +242,7 @@ public class WSO2UserOperationEventPayloadBuilderTest {
     public void testBuildUserDeleteEvent() throws IdentityEventException, UserStoreException {
 
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.USER_DELETE)
+                .name(Flow.Name.USER_ACCOUNT_DELETE)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
 
@@ -299,7 +299,7 @@ public class WSO2UserOperationEventPayloadBuilderTest {
                 eq(FrameworkConstants.USER_ID_CLAIM), any())).thenReturn(TEST_USER_ID);
 
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.ACCOUNT_UNLOCK)
+                .name(Flow.Name.USER_ACCOUNT_UNLOCK)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
 
@@ -345,7 +345,7 @@ public class WSO2UserOperationEventPayloadBuilderTest {
                 eq(FrameworkConstants.USER_ID_CLAIM), any())).thenReturn(TEST_USER_ID);
 
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.ACCOUNT_LOCK)
+                .name(Flow.Name.USER_ACCOUNT_LOCK)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
 
@@ -404,7 +404,7 @@ public class WSO2UserOperationEventPayloadBuilderTest {
                 eq(FrameworkConstants.EMAIL_ADDRESS_CLAIM), any())).thenReturn(TEST_USER_EMAIL);
 
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.ACCOUNT_DISABLE) //TODO change the flow when introduce ACCOUNT_ENABLE
+                .name(Flow.Name.USER_ACCOUNT_ENABLE)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
 
@@ -442,7 +442,7 @@ public class WSO2UserOperationEventPayloadBuilderTest {
                 eq(FrameworkConstants.EMAIL_ADDRESS_CLAIM), any())).thenReturn(TEST_USER_EMAIL);
 
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.ACCOUNT_DISABLE)
+                .name(Flow.Name.USER_ACCOUNT_DISABLE)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
 
@@ -484,7 +484,7 @@ public class WSO2UserOperationEventPayloadBuilderTest {
         when(mockEventData.getEventParams()).thenReturn(params);
 
         IdentityContext.getThreadLocalIdentityContext().setFlow(new Flow.Builder()
-                .name(Flow.Name.USER_REGISTRATION_INVITE_WITH_PASSWORD)
+                .name(Flow.Name.INVITE)
                 .initiatingPersona(Flow.InitiatingPersona.ADMIN)
                 .build());
 
@@ -499,8 +499,7 @@ public class WSO2UserOperationEventPayloadBuilderTest {
         assertEquals(userAccountEventPayload.getUser().getRef(),
                 constructFullURLWithEndpoint(SCIM2_USERS_ENDPOINT) + "/" + TEST_USER_ID);
         assertNotNull(userAccountEventPayload.getAction());
-        assertEquals(userAccountEventPayload.getAction(),
-                WSO2RegistrationEventPayloadBuilder.RegistrationAction.INVITE.name());
+        assertEquals(userAccountEventPayload.getAction(), Flow.Name.INVITE.name());
         assertNotNull(userAccountEventPayload.getUser().getClaims());
         assertEquals(userAccountEventPayload.getUser().getClaims().size(), 3);
 

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.8.318</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.340</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Saving this as a draft since there is a refactoring PR which should be merged before this

- https://github.com/wso2-extensions/identity-webhook-event-handlers/pull/25

This update adopts the latest flow names for registration-related functionality, which impacts the following areas:
- Actions
- Newly introduced webhook events

This is a breaking change and should only be merged once all related pull requests are ready and tested together in a WSO2 Identity Server pack(Integration tests locally) that includes all required modifications.

Possible repositories of the PRs

- Framework
- Identity Governance
- Webhook Event Handlers
- SCIM2

Parent issue
- https://github.com/wso2/product-is/issues/24847