### PR TITLE
Handle B2B Event Issuer

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
@@ -173,14 +173,13 @@ public class EventHookHandlerUtils {
         try {
             IdentityContext identityContext = IdentityContext.getThreadLocalIdentityContext();
             if (identityContext.getOrganization() != null && identityContext.getOrganization().getDepth() != 0) {
-                String organizationHandle = identityContext.getOrganization().getOrganizationHandle();
+                String rootTenantDomain = identityContext.getRootOrganization().getAssociatedTenantDomain();
                 String organizationId = identityContext.getOrganization().getId();
-                if (organizationHandle != null && organizationId != null) {
-                    log.debug("Resolving organization handle: " + organizationHandle +
+                if (rootTenantDomain != null && organizationId != null) {
+                    log.debug("Resolving root tenant: " + rootTenantDomain +
                             " and organization ID: " + organizationId);
-
                     ServiceURLBuilder builder =
-                            ServiceURLBuilder.create().addPath("/t/" + organizationHandle + "/o/" + organizationId);
+                            ServiceURLBuilder.create().addPath("/t/" + rootTenantDomain + "/o/" + organizationId);
                     return builder.build().getAbsolutePublicURL();
                 }
             }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
@@ -171,6 +171,19 @@ public class EventHookHandlerUtils {
     public static String constructBaseURL() {
 
         try {
+            IdentityContext identityContext = IdentityContext.getThreadLocalIdentityContext();
+            if (identityContext.getOrganization() != null && identityContext.getOrganization().getDepth() != 0) {
+                String organizationHandle = identityContext.getOrganization().getOrganizationHandle();
+                String organizationId = identityContext.getOrganization().getId();
+                if (organizationHandle != null && organizationId != null) {
+                    log.debug("Resolving organization handle: " + organizationHandle +
+                            " and organization ID: " + organizationId);
+
+                    ServiceURLBuilder builder =
+                            ServiceURLBuilder.create().addPath("/t/" + organizationHandle + "/o/" + organizationId);
+                    return builder.build().getAbsolutePublicURL();
+                }
+            }
             ServiceURLBuilder builder = ServiceURLBuilder.create();
             return builder.build().getAbsolutePublicURL();
         } catch (URLBuilderException e) {


### PR DESCRIPTION
### Proposed changes in this pull request


This pull request enhances the `constructBaseURL` method in the `EventHookHandlerUtils` utility class to support organization-specific URL resolution. The changes ensure that if the current identity context includes an organization with a valid handle and ID, the generated base URL incorporates these details.

### Enhancements to organization-specific URL resolution:

* [`components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java`](diffhunk://#diff-cab9d7e2a93d166dd0f253b0b38403872efa6e82c24fcf08a9e42efae611ad10R174-R186): Updated the `constructBaseURL` method to check if the `IdentityContext` contains an organization with a non-zero depth. If valid `organizationHandle` and `organizationId` are present, the method constructs a URL path segment using these values and appends it to the base URL. Added debug logging to provide visibility into the resolved organization details.
