### PR TITLE
Add root tenant url resolver for root tenant events

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
@@ -172,14 +172,11 @@ public class EventHookHandlerUtils {
 
         try {
             IdentityContext identityContext = IdentityContext.getThreadLocalIdentityContext();
-            if (identityContext.getRootOrganization() == null &&
+            if (identityContext.getRootOrganization() == null ||
                     StringUtils.isBlank(identityContext.getRootOrganization().getAssociatedTenantDomain())) {
                 return null;
             }
             String rootTenantDomain = identityContext.getRootOrganization().getAssociatedTenantDomain();
-            if (StringUtils.isBlank(rootTenantDomain)) {
-                return null;
-            }
 
             if (identityContext.getOrganization() != null && identityContext.getOrganization().getDepth() != 0) {
                 String organizationId = identityContext.getOrganization().getId();

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
@@ -172,23 +172,36 @@ public class EventHookHandlerUtils {
 
         try {
             IdentityContext identityContext = IdentityContext.getThreadLocalIdentityContext();
+            if (identityContext.getRootOrganization() == null &&
+                    StringUtils.isBlank(identityContext.getRootOrganization().getAssociatedTenantDomain())) {
+                return null;
+            }
+            String rootTenantDomain = identityContext.getRootOrganization().getAssociatedTenantDomain();
+            if (StringUtils.isBlank(rootTenantDomain)) {
+                return null;
+            }
+
             if (identityContext.getOrganization() != null && identityContext.getOrganization().getDepth() != 0) {
-                String rootTenantDomain = identityContext.getRootOrganization().getAssociatedTenantDomain();
                 String organizationId = identityContext.getOrganization().getId();
-                if (rootTenantDomain != null && organizationId != null) {
+                if (StringUtils.isNotBlank(organizationId)) {
                     log.debug("Resolving root tenant: " + rootTenantDomain +
                             " and organization ID: " + organizationId);
-                    ServiceURLBuilder builder =
-                            ServiceURLBuilder.create().addPath("/t/" + rootTenantDomain + "/o/" + organizationId);
-                    return builder.build().getAbsolutePublicURL();
+                    return ServiceURLBuilder.create()
+                            .addPath("/t/" + rootTenantDomain + "/o/" + organizationId)
+                            .build()
+                            .getAbsolutePublicURL();
                 }
             }
-            ServiceURLBuilder builder = ServiceURLBuilder.create();
-            return builder.build().getAbsolutePublicURL();
+
+            return ServiceURLBuilder.create()
+                    .addPath("/t/" + rootTenantDomain)
+                    .build()
+                    .getAbsolutePublicURL();
+
         } catch (URLBuilderException e) {
             log.debug("Error occurred while building the tenant qualified URL.", e);
+            return null;
         }
-        return null;
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request


This pull request refactors the `constructBaseURL` method in `EventHookHandlerUtils.java` to improve null and blank checks, streamline the URL construction logic, and enhance code readability. The changes ensure that the method handles edge cases more robustly and avoids unnecessary operations.

### Improvements to null and blank checks:

* Added checks for `identityContext.getRootOrganization()` and its associated tenant domain to ensure they are not null or blank before proceeding with URL construction. This prevents potential null pointer exceptions.

### Streamlined URL construction:

* Refactored the URL-building logic to avoid redundant operations. If the organization ID is valid, the method constructs a tenant-qualified URL with both the root tenant domain and organization ID. Otherwise, it constructs a URL with just the root tenant domain.

### Enhanced readability:

* Simplified the method by removing unnecessary variable assignments and consolidating the URL-building logic into fewer, clearer steps.