### PR TITLE
Unit test fixes

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/api/util/EventPayloadUtilsTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/api/util/EventPayloadUtilsTest.java
@@ -19,7 +19,7 @@
 package org.wso2.identity.webhook.common.event.handler.api.util;
 
 import org.mockito.MockitoAnnotations;
-import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.identity.webhook.common.event.handler.internal.util.EventHookHandlerUtils;
@@ -39,10 +39,11 @@ public class EventPayloadUtilsTest {
         MockitoAnnotations.openMocks(this);
     }
 
-    @AfterClass
+    @AfterMethod
     public void tearDown() {
-        // Clean up resources if needed
-        closeMockedServiceURLBuilder();
+
+        TestUtils.closeMockedServiceURLBuilder();
+        TestUtils.closeMockedIdentityTenantUtil();
     }
 
     @Test

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/util/TestUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/util/TestUtils.java
@@ -37,6 +37,9 @@ public class TestUtils {
     private static MockedStatic<ServiceURLBuilder> mockedStaticServiceURLBuilder;
     private static MockedStatic<IdentityTenantUtil> mockedStaticIdentityTenantUtil;
 
+    /**
+     * Mocks the ServiceURLBuilder.
+     */
     public static void mockServiceURLBuilder() {
         // Close previous static mock if still open
         if (mockedStaticServiceURLBuilder != null && !mockedStaticServiceURLBuilder.isClosed()) {
@@ -85,6 +88,9 @@ public class TestUtils {
         when(ServiceURLBuilder.create()).thenReturn(builder);
     }
 
+    /**
+     * Closes the mocked ServiceURLBuilder.
+     */
     public static void closeMockedServiceURLBuilder() {
 
         if (mockedStaticServiceURLBuilder != null && !mockedStaticServiceURLBuilder.isClosed()) {
@@ -92,6 +98,9 @@ public class TestUtils {
         }
     }
 
+    /**
+     * Mocks the IdentityTenantUtil.
+     */
     public static void mockIdentityTenantUtil() {
 
         if (mockedStaticIdentityTenantUtil != null && !mockedStaticIdentityTenantUtil.isClosed()) {
@@ -102,6 +111,9 @@ public class TestUtils {
         when(IdentityTenantUtil.getTenantId(SAMPLE_TENANT_DOMAIN)).thenReturn(SAMPLE_TENANT_ID);
     }
 
+    /**
+     * Closes the mocked IdentityTenantUtil.
+     */
     public static void closeMockedIdentityTenantUtil() {
 
         if (mockedStaticIdentityTenantUtil != null && !mockedStaticIdentityTenantUtil.isClosed()) {

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/util/TestUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/util/TestUtils.java
@@ -23,8 +23,6 @@ import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
-import java.util.Arrays;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -39,10 +37,11 @@ public class TestUtils {
     private static MockedStatic<ServiceURLBuilder> mockedStaticServiceURLBuilder;
     private static MockedStatic<IdentityTenantUtil> mockedStaticIdentityTenantUtil;
 
-    /**
-     * Mocks the ServiceURLBuilder.
-     */
     public static void mockServiceURLBuilder() {
+        // Close previous static mock if still open
+        if (mockedStaticServiceURLBuilder != null && !mockedStaticServiceURLBuilder.isClosed()) {
+            mockedStaticServiceURLBuilder.close();
+        }
 
         ServiceURLBuilder builder = new ServiceURLBuilder() {
             String path = "";
@@ -50,7 +49,6 @@ public class TestUtils {
             @Override
             public ServiceURLBuilder addPath(String... strings) {
 
-                Arrays.stream(strings).forEach(x -> path += "/" + x);
                 return this;
             }
 
@@ -87,9 +85,6 @@ public class TestUtils {
         when(ServiceURLBuilder.create()).thenReturn(builder);
     }
 
-    /**
-     * Closes the mocked ServiceURLBuilder.
-     */
     public static void closeMockedServiceURLBuilder() {
 
         if (mockedStaticServiceURLBuilder != null && !mockedStaticServiceURLBuilder.isClosed()) {
@@ -97,19 +92,16 @@ public class TestUtils {
         }
     }
 
-    /**
-     * Mocks the IdentityTenantUtil.
-     */
     public static void mockIdentityTenantUtil() {
 
+        if (mockedStaticIdentityTenantUtil != null && !mockedStaticIdentityTenantUtil.isClosed()) {
+            mockedStaticIdentityTenantUtil.close();
+        }
         mockedStaticIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
         when(IdentityTenantUtil.isTenantedSessionsEnabled()).thenReturn(false);
         when(IdentityTenantUtil.getTenantId(SAMPLE_TENANT_DOMAIN)).thenReturn(SAMPLE_TENANT_ID);
     }
 
-    /**
-     * Closes the mocked IdentityTenantUtil.
-     */
     public static void closeMockedIdentityTenantUtil() {
 
         if (mockedStaticIdentityTenantUtil != null && !mockedStaticIdentityTenantUtil.isClosed()) {


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request focuses on improving test cleanup and mocking practices in the `EventPayloadUtilsTest` and `EventHookHandlerUtilsTest` classes, as well as enhancing utility methods in the `TestUtils` class. The changes ensure better resource management and more robust test setups.

### Improvements to test cleanup:

* Replaced `@AfterClass` with `@AfterMethod` in `EventPayloadUtilsTest` to ensure resources are cleaned up after each test method. Updated the `tearDown` method to use `TestUtils` for closing mocked resources (`closeMockedServiceURLBuilder` and `closeMockedIdentityTenantUtil`). [[1]](diffhunk://#diff-6e896cc6e44e6e2a6da957b82dde104bda2e144a06a0eb6adaf34c8d6a344ce7L22-R22) [[2]](diffhunk://#diff-6e896cc6e44e6e2a6da957b82dde104bda2e144a06a0eb6adaf34c8d6a344ce7L42-R46)

* Added an `@AfterMethod` in `EventHookHandlerUtilsTest` to clean up mocked resources after each test. This ensures proper teardown of static mocks.

### Enhancements to mocking:

* Introduced static mocking for `IdentityContext` and its associated methods in `EventHookHandlerUtilsTest`. This includes mocking `getRootOrganization` and `getThreadLocalIdentityContext` to simulate tenant-related operations. [[1]](diffhunk://#diff-c6814bcdb648f154798299c4921cde4ab84cbfd65014f54fe393f4efe3034117R82-R87) [[2]](diffhunk://#diff-c6814bcdb648f154798299c4921cde4ab84cbfd65014f54fe393f4efe3034117R108-R132)

### Updates to utility methods:

* Improved the `TestUtils` class by adding safeguards to close existing static mocks (`ServiceURLBuilder` and `IdentityTenantUtil`) before reinitializing them. This prevents potential conflicts or memory leaks in tests. [[1]](diffhunk://#diff-1a81b18f01046bc3b3f9333a97196c27d376ffb070f15fb94f0b08ad457ddfe0L42-L53) [[2]](diffhunk://#diff-1a81b18f01046bc3b3f9333a97196c27d376ffb070f15fb94f0b08ad457ddfe0L90-L112)