### PR TITLE
Skip b2b user federated login event

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java
@@ -163,6 +163,13 @@ public class LoginEventHookHandler extends AbstractEventHandler {
             return;
         }
 
+        if (EventHookHandlerUtils.isB2BUserLogin(eventData.getAuthenticationContext())) {
+            log.debug(
+                    "Login event is triggered for a B2B user federation. Skipping event handling for login event profile: " +
+                            eventProfile.getProfile());
+            return;
+        }
+
         // Publish for current accessing org
         String tenantDomain = eventData.getAuthenticationContext().getLoginTenantDomain();
         publishEvent(tenantDomain, loginChannel, eventUri, eventProfile.getProfile(),

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStatus;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
@@ -336,6 +337,19 @@ public class EventHookHandlerUtils {
         return metadataProperties != null &&
                 Objects.equals(metadataProperties.getOrganizationPolicy().getPolicyCode(),
                         PolicyEnum.IMMEDIATE_EXISTING_AND_FUTURE_ORGS.getPolicyCode());
+    }
+
+    public static boolean isB2BUserLogin(AuthenticationContext authContext) {
+
+        for (AuthHistory authHistory : authContext.getAuthenticationStepHistory()) {
+            /*
+             * For the B2B user scenario, the authentication method 'OrganizationAuthenticator'
+             */
+            if (authHistory.toTranslatableString().equals(FrameworkConstants.ORGANIZATION_AUTHENTICATOR)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Map<String, Object> validateAndGetProperties(Event event) throws IdentityEventException {


### PR DESCRIPTION
### Proposed changes in this pull request


This pull request introduces logic to correctly handle login events for B2B user federation scenarios, ensuring that such events are skipped during event handling. The main changes include a new utility method for B2B login detection and its integration into the login event handler.

**B2B User Federation Handling:**

* Added a check in `LoginEventHookHandler.java` to skip login event handling when the user is authenticated via B2B federation, using a new utility method.
* Implemented the `isB2BUserLogin(AuthenticationContext authContext)` method in `EventHookHandlerUtils.java` to detect B2B logins by inspecting authentication history for the `OrganizationAuthenticator`.

**Imports and Dependencies:**

* Added import for `AuthHistory` in `EventHookHandlerUtils.java` to support the new B2B login detection logic.
