### PR TITLE
Add user resident organization to the user event payload

### DIFF
--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2CredentialEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2CredentialEventPayloadBuilder.java
@@ -72,6 +72,7 @@ public class WSO2CredentialEventPayloadBuilder implements CredentialEventPayload
         }
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
 
         return new WSO2UserCredentialUpdateEventPayload.Builder()
                 .initiatorType(initiatorType)

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2LoginEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2LoginEventPayloadBuilder.java
@@ -79,6 +79,7 @@ public class WSO2LoginEventPayloadBuilder implements LoginEventPayloadBuilder {
         }
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
         Application application = new Application(
                 authenticationContext.getServiceProviderResourceId(),
                 authenticationContext.getServiceProviderName());
@@ -133,6 +134,7 @@ public class WSO2LoginEventPayloadBuilder implements LoginEventPayloadBuilder {
                 authenticationContext.getServiceProviderName());
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
         return new WSO2AuthenticationFailedEventPayload.Builder()
                 .user(user)
                 .tenant(tenant)

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RegistrationEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RegistrationEventPayloadBuilder.java
@@ -83,6 +83,7 @@ public class WSO2RegistrationEventPayloadBuilder implements RegistrationEventPay
         }
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        newUser.setOrganization(organization);
 
         return new WSO2RegistrationSuccessEventPayload.Builder()
                 .initiatorType(initiatorType)
@@ -150,6 +151,7 @@ public class WSO2RegistrationEventPayloadBuilder implements RegistrationEventPay
         Reason reason = new Reason(errorMessage, context);
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        newUser.setOrganization(organization);
 
         return new WSO2RegistrationFailureEventPayload.Builder()
                 .initiatorType(initiatorType)

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2SessionEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2SessionEventPayloadBuilder.java
@@ -63,6 +63,7 @@ public class WSO2SessionEventPayloadBuilder implements SessionEventPayloadBuilde
         Application application = buildApplication(eventData.getAuthenticationContext());
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
 
         return new WSO2SessionCreatedEventPayload.Builder()
                 .session(sessions != null && !sessions.isEmpty() ? sessions.get(0) : null)
@@ -84,6 +85,7 @@ public class WSO2SessionEventPayloadBuilder implements SessionEventPayloadBuilde
         Application application = buildApplication(eventData.getAuthenticationContext());
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
 
         return new WSO2SessionPresentedEventPayload.Builder()
                 .session(sessions != null && !sessions.isEmpty() ? sessions.get(0) : null)
@@ -104,6 +106,7 @@ public class WSO2SessionEventPayloadBuilder implements SessionEventPayloadBuilde
         List<Session> sessions = getSessions(eventData);
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
 
         return new WSO2SessionRevokedEventPayload.Builder()
                 .user(user)

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2UserOperationEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2UserOperationEventPayloadBuilder.java
@@ -147,6 +147,7 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
             }
             Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                     IdentityContext.getThreadLocalIdentityContext());
+            deletedUser.setOrganization(organization);
 
             return new WSO2UserAccountEventPayload.Builder()
                     .initiatorType(initiatorType)
@@ -197,6 +198,7 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
         }
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
 
         return new WSO2UserAccountEventPayload.Builder()
                 .user(user)
@@ -244,6 +246,7 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
         }
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
 
         return new WSO2UserAccountEventPayload.Builder()
                 .initiatorType(initiatorType)
@@ -309,6 +312,7 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
         }
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        user.setOrganization(organization);
 
         return new WSO2UserAccountEventPayload.Builder()
                 .initiatorType(initiatorType)
@@ -368,6 +372,7 @@ public class WSO2UserOperationEventPayloadBuilder implements UserOperationEventP
         }
         Organization organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
                 IdentityContext.getThreadLocalIdentityContext());
+        newUser.setOrganization(organization);
 
         return new WSO2UserCreatedEventPayload.Builder()
                 .initiatorType(initiatorType)

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/User.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/User.java
@@ -28,6 +28,7 @@ public class User {
 
     private String id;
     private List<UserClaim> claims;
+    private Organization organization;
     private String ref;
     private List<String> groups = new ArrayList<>();
     private List<String> roles = new ArrayList<>();
@@ -44,6 +45,26 @@ public class User {
     public void setGroups(List<String> groups) {
 
         this.groups = groups;
+    }
+
+    /**
+     * Get the organization of the user.
+     *
+     * @return Organization of the user.
+     */
+    public Organization getOrganization() {
+
+        return organization;
+    }
+
+    /**
+     * Set the organization of the user.
+     *
+     * @param organization Organization of the user.
+     */
+    public void setOrganization(Organization organization) {
+
+        this.organization = organization;
     }
 
     public void addGroup(String group) {


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request enhances the event payload models by ensuring that the `Organization` information is consistently included in all user-related event payloads. The main change is the addition of an `organization` field to the `User` model, along with corresponding getter and setter methods. All event payload builders are updated to set the organization on the user object before building the payload, ensuring that organization context is available in webhook events.

**Model enhancements:**

* Added a new `organization` field to the `User` class, along with its getter and setter methods. [[1]](diffhunk://#diff-972e1d485aea0a46bff904c41c79bbbf0d717f0ee42779dffc3f8ecd968a2f07R31) [[2]](diffhunk://#diff-972e1d485aea0a46bff904c41c79bbbf0d717f0ee42779dffc3f8ecd968a2f07R50-R69)

**Event payload builder updates:**

* Updated all relevant event payload builder methods (`WSO2LoginEventPayloadBuilder`, `WSO2RegistrationEventPayloadBuilder`, `WSO2SessionEventPayloadBuilder`, `WSO2UserOperationEventPayloadBuilder`, `WSO2CredentialEventPayloadBuilder`) to set the organization on the user object using `user.setOrganization(organization)` before constructing the event payload. [[1]](diffhunk://#diff-a90a0e19d18ac887ddec51ddb84be879fb4fd9389c8acbd002d9882178e824eaR82) [[2]](diffhunk://#diff-a90a0e19d18ac887ddec51ddb84be879fb4fd9389c8acbd002d9882178e824eaR137) [[3]](diffhunk://#diff-1f1a232e639965a5bd7aff2cc71b767d2a385b3f2e6ba2d69fb5c270e1ac9515R86) [[4]](diffhunk://#diff-1f1a232e639965a5bd7aff2cc71b767d2a385b3f2e6ba2d69fb5c270e1ac9515R154) [[5]](diffhunk://#diff-1e8ff2e68e6a9dd2572e4692c099105fe84c1f8bfa5b55b5643a526313469ae4R66) [[6]](diffhunk://#diff-1e8ff2e68e6a9dd2572e4692c099105fe84c1f8bfa5b55b5643a526313469ae4R88) [[7]](diffhunk://#diff-1e8ff2e68e6a9dd2572e4692c099105fe84c1f8bfa5b55b5643a526313469ae4R109) [[8]](diffhunk://#diff-bed27e6c981e3d6ee09143208d11c56b61b4652768b6b16e24a40166acce44a7R150) [[9]](diffhunk://#diff-bed27e6c981e3d6ee09143208d11c56b61b4652768b6b16e24a40166acce44a7R201) [[10]](diffhunk://#diff-bed27e6c981e3d6ee09143208d11c56b61b4652768b6b16e24a40166acce44a7R249) [[11]](diffhunk://#diff-bed27e6c981e3d6ee09143208d11c56b61b4652768b6b16e24a40166acce44a7R315) [[12]](diffhunk://#diff-bed27e6c981e3d6ee09143208d11c56b61b4652768b6b16e24a40166acce44a7R375) [[13]](diffhunk://#diff-0a1c9da56660f5420768b21050dc3655a9586e3d42e5b28f313b5abfcf02f0acR75)

These changes ensure that the organization context is always included with user information in event payloads, improving the completeness and traceability of webhook events.
