### PR TITLE
Remove b2b webhook feature execution

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/CredentialEventHookHandler.java
@@ -33,8 +33,6 @@ import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherExce
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
-import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
 import org.wso2.carbon.identity.webhook.metadata.api.model.Channel;
 import org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile;
 import org.wso2.identity.webhook.common.event.handler.api.builder.CredentialEventPayloadBuilder;
@@ -108,8 +106,7 @@ public class CredentialEventHookHandler extends AbstractEventHandler {
     }
 
     private void handleEventForProfile(Event event, EventProfile eventProfile)
-            throws IdentityEventException, EventPublisherException, OrganizationManagementException,
-            WebhookMetadataException {
+            throws IdentityEventException, EventPublisherException {
         // Prepare schema, payload builder, and event data
         org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema schema =
                 org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema.valueOf(
@@ -149,13 +146,6 @@ public class CredentialEventHookHandler extends AbstractEventHandler {
                 eventData.getEventParams().get(IdentityEventConstants.EventProperty.TENANT_DOMAIN));
         publishCredentialEvent(tenantDomain, credentialChangeChannel, eventUri, eventProfile.getProfile(),
                 payloadBuilder, eventData, event.getEventName());
-
-        // Publish for immediate parent org if policy allows
-        String parentTenantDomain = EventHookHandlerUtils.resolveParentTenantDomain();
-        if (parentTenantDomain != null && EventHookHandlerUtils.isParentPolicyImmediateOrgs(parentTenantDomain)) {
-            publishCredentialEvent(parentTenantDomain, credentialChangeChannel, eventUri, eventProfile.getProfile(),
-                    payloadBuilder, eventData, event.getEventName());
-        }
     }
 
     private boolean isSupportedEvent(String eventName) {

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/LoginEventHookHandler.java
@@ -32,8 +32,6 @@ import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherExce
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
-import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
 import org.wso2.carbon.identity.webhook.metadata.api.model.Channel;
 import org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile;
 import org.wso2.identity.webhook.common.event.handler.api.builder.LoginEventPayloadBuilder;
@@ -115,8 +113,7 @@ public class LoginEventHookHandler extends AbstractEventHandler {
     }
 
     private void handleEventForProfile(Event event, EventData eventData, EventProfile eventProfile)
-            throws IdentityEventException, EventPublisherException, OrganizationManagementException,
-            WebhookMetadataException {
+            throws IdentityEventException, EventPublisherException {
 
         // Prepare schema, payload builder, and event metadata
         org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema schema =
@@ -176,13 +173,6 @@ public class LoginEventHookHandler extends AbstractEventHandler {
         String tenantDomain = eventData.getAuthenticationContext().getLoginTenantDomain();
         publishEvent(tenantDomain, loginChannel, eventUri, eventProfile.getProfile(),
                 payloadBuilder, eventData, event.getEventName());
-
-        // Publish for immediate parent org if policy allows
-        String parentTenantDomain = EventHookHandlerUtils.resolveParentTenantDomain();
-        if (parentTenantDomain != null && EventHookHandlerUtils.isParentPolicyImmediateOrgs(parentTenantDomain)) {
-            publishEvent(parentTenantDomain, loginChannel, eventUri, eventProfile.getProfile(),
-                    payloadBuilder, eventData, event.getEventName());
-        }
     }
 
     private void publishEvent(String tenantDomain, Channel loginChannel, String eventUri, String eventProfileName,

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RegistrationEventHookHandler.java
@@ -33,8 +33,6 @@ import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherExce
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
-import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
 import org.wso2.carbon.identity.webhook.metadata.api.model.Channel;
 import org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile;
 import org.wso2.identity.webhook.common.event.handler.api.builder.RegistrationEventPayloadBuilder;
@@ -110,8 +108,7 @@ public class RegistrationEventHookHandler extends AbstractEventHandler {
     }
 
     private void handleEventForProfile(Event event, EventProfile eventProfile)
-            throws IdentityEventException, EventPublisherException, OrganizationManagementException,
-            WebhookMetadataException {
+            throws IdentityEventException, EventPublisherException {
 
         // Prepare schema, payload builder, and event data
         org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema schema =
@@ -153,13 +150,6 @@ public class RegistrationEventHookHandler extends AbstractEventHandler {
         String tenantDomain = eventData.getTenantDomain();
         publishRegistrationEvent(tenantDomain, registrationChannel, eventUri, eventProfile.getProfile(),
                 payloadBuilder, eventData, event.getEventName());
-
-        // Publish for immediate parent org if policy allows
-        String parentTenantDomain = EventHookHandlerUtils.resolveParentTenantDomain();
-        if (parentTenantDomain != null && EventHookHandlerUtils.isParentPolicyImmediateOrgs(parentTenantDomain)) {
-            publishRegistrationEvent(parentTenantDomain, registrationChannel, eventUri, eventProfile.getProfile(),
-                    payloadBuilder, eventData, event.getEventName());
-        }
     }
 
     private boolean isSupportedEvent(String eventName) {

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/SessionEventHookHandler.java
@@ -29,7 +29,6 @@ import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.common.Subject;
-import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
 import org.wso2.carbon.identity.webhook.metadata.api.model.Channel;
 import org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile;
@@ -82,7 +81,7 @@ public class SessionEventHookHandler extends AbstractEventHandler {
     }
 
     private void handleEventPerEventProfile(Event event, EventData eventData, EventProfile eventProfile)
-            throws IdentityEventException, OrganizationManagementException, WebhookMetadataException {
+            throws IdentityEventException {
 
         // Prepare schema, payload builder, and event metadata
         org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema schema =
@@ -118,13 +117,6 @@ public class SessionEventHookHandler extends AbstractEventHandler {
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         publishSessionEvent(tenantDomain, sessionChannel, eventUri, eventProfile.getProfile(), schema,
                 payloadBuilder, eventData, event);
-
-        // Publish for immediate parent org if policy allows
-        String parentTenantDomain = EventHookHandlerUtils.resolveParentTenantDomain();
-        if (parentTenantDomain != null && EventHookHandlerUtils.isParentPolicyImmediateOrgs(parentTenantDomain)) {
-            publishSessionEvent(parentTenantDomain, sessionChannel, eventUri, eventProfile.getProfile(), schema,
-                    payloadBuilder, eventData, event);
-        }
     }
 
     private List<EventProfile> getEventProfiles() {

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/TokenEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/TokenEventHookHandler.java
@@ -29,8 +29,6 @@ import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherExce
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
-import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
 import org.wso2.carbon.identity.webhook.metadata.api.model.Channel;
 import org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile;
 import org.wso2.identity.webhook.common.event.handler.api.builder.TokenEventPayloadBuilder;
@@ -80,8 +78,7 @@ public class TokenEventHookHandler extends AbstractEventHandler {
     }
 
     private void handleEventForProfile(Event event, EventData eventData, EventProfile eventProfile)
-            throws IdentityEventException, EventPublisherException, OrganizationManagementException,
-            WebhookMetadataException {
+            throws IdentityEventException, EventPublisherException {
 
         // Prepare schema, payload builder, and event metadata
         org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema schema =
@@ -122,13 +119,6 @@ public class TokenEventHookHandler extends AbstractEventHandler {
         String tenantDomain = eventData.getAuthenticationContext().getTenantDomain();
         publishEvent(tenantDomain, tokenChannel, eventUri, eventProfile.getProfile(),
                 payloadBuilder, eventData, event.getEventName());
-
-        // Publish for immediate parent org if policy allows
-        String parentTenantDomain = EventHookHandlerUtils.resolveParentTenantDomain();
-        if (parentTenantDomain != null && EventHookHandlerUtils.isParentPolicyImmediateOrgs(parentTenantDomain)) {
-            publishEvent(parentTenantDomain, tokenChannel, eventUri, eventProfile.getProfile(),
-                    payloadBuilder, eventData, event.getEventName());
-        }
     }
 
     private void publishEvent(String tenantDomain, Channel tokenChannel, String eventUri, String eventProfileName,

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/UserOperationEventHookHandler.java
@@ -34,8 +34,6 @@ import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherExce
 import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
 import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
 import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
-import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
 import org.wso2.carbon.identity.webhook.metadata.api.model.Channel;
 import org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile;
 import org.wso2.identity.webhook.common.event.handler.api.builder.UserOperationEventPayloadBuilder;
@@ -117,8 +115,7 @@ public class UserOperationEventHookHandler extends AbstractEventHandler {
     }
 
     private void handleEventPerProfile(Event event, EventProfile eventProfile)
-            throws IdentityEventException, EventPublisherException, OrganizationManagementException,
-            WebhookMetadataException {
+            throws IdentityEventException, EventPublisherException {
 
         // Prepare schema, payload builder, and event metadata
         org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema schema =
@@ -158,13 +155,6 @@ public class UserOperationEventHookHandler extends AbstractEventHandler {
         // Publish for current accessing org
         publishUserOperationEvent(tenantDomain, userOperationChannel, eventUri, eventProfile.getProfile(),
                 payloadBuilder, eventData, event.getEventName());
-
-        // Publish for immediate parent org if policy allows
-        String parentTenantDomain = EventHookHandlerUtils.resolveParentTenantDomain();
-        if (parentTenantDomain != null && EventHookHandlerUtils.isParentPolicyImmediateOrgs(parentTenantDomain)) {
-            publishUserOperationEvent(parentTenantDomain, userOperationChannel, eventUri, eventProfile.getProfile(),
-                    payloadBuilder, eventData, event.getEventName());
-        }
     }
 
     private boolean isSupportedEvent(String eventName) {


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request simplifies the event handler classes by removing logic related to publishing events to immediate parent organizations and by cleaning up unused exception imports and method signatures. The changes streamline event processing and reduce unnecessary complexity.

**Removal of parent organization event publishing logic:**

- Removed the code that published events for immediate parent organizations if policy allowed, from all event handler classes (`CredentialEventHookHandler`, `LoginEventHookHandler`, `RegistrationEventHookHandler`, `SessionEventHookHandler`, `TokenEventHookHandler`, `UserOperationEventHookHandler`). Now, events are only published for the current tenant/organization. [[1]](diffhunk://#diff-deaf1dd299a29da4f6559edd65715eab61547dd24a63d68f8cac4f3b19b53a83L152-L158) [[2]](diffhunk://#diff-201d7cf4ab2807ba5ebbf08c7bb5be2f1e5fc651e74f0b429537d7b6967fe229L179-L185) [[3]](diffhunk://#diff-6775a58bbd20c2071a3901b29830badbe7f31a9fc1dfdd76f33e64dbd56a0b02L156-L162) [[4]](diffhunk://#diff-4571638571b75bee71408e6570f025bb14838f8e72bb57e9111a7280560b9a26L121-L127) [[5]](diffhunk://#diff-af96944a206d1937fdfb2798dc01097771283582a3918108d2d53eae5230b196L125-L131) [[6]](diffhunk://#diff-d8d81195782868e827e34ec8e30ac09ee4d4d09a5817f61a6cd443862eb206e4L161-L167)

**Exception handling and import cleanup:**

- Removed unused exception imports (`OrganizationManagementException`, `WebhookMetadataException`) from all event handler classes, as these exceptions are no longer thrown or needed. [[1]](diffhunk://#diff-deaf1dd299a29da4f6559edd65715eab61547dd24a63d68f8cac4f3b19b53a83L36-L37) [[2]](diffhunk://#diff-201d7cf4ab2807ba5ebbf08c7bb5be2f1e5fc651e74f0b429537d7b6967fe229L35-L36) [[3]](diffhunk://#diff-6775a58bbd20c2071a3901b29830badbe7f31a9fc1dfdd76f33e64dbd56a0b02L36-L37) [[4]](diffhunk://#diff-4571638571b75bee71408e6570f025bb14838f8e72bb57e9111a7280560b9a26L32) [[5]](diffhunk://#diff-af96944a206d1937fdfb2798dc01097771283582a3918108d2d53eae5230b196L32-L33) [[6]](diffhunk://#diff-d8d81195782868e827e34ec8e30ac09ee4d4d09a5817f61a6cd443862eb206e4L37-L38)
- Updated method signatures in all event handler classes to remove the now-unnecessary exceptions from the `throws` clause, further simplifying the code. [[1]](diffhunk://#diff-deaf1dd299a29da4f6559edd65715eab61547dd24a63d68f8cac4f3b19b53a83L111-R109) [[2]](diffhunk://#diff-201d7cf4ab2807ba5ebbf08c7bb5be2f1e5fc651e74f0b429537d7b6967fe229L118-R116) [[3]](diffhunk://#diff-6775a58bbd20c2071a3901b29830badbe7f31a9fc1dfdd76f33e64dbd56a0b02L113-R111) [[4]](diffhunk://#diff-4571638571b75bee71408e6570f025bb14838f8e72bb57e9111a7280560b9a26L85-R84) [[5]](diffhunk://#diff-af96944a206d1937fdfb2798dc01097771283582a3918108d2d53eae5230b196L83-R81) [[6]](diffhunk://#diff-d8d81195782868e827e34ec8e30ac09ee4d4d09a5817f61a6cd443862eb206e4L120-R118)