### PR TITLE
Remove unused b2b util

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayl
 import org.wso2.carbon.identity.event.publisher.api.model.common.ComplexSubject;
 import org.wso2.carbon.identity.event.publisher.api.model.common.SimpleSubject;
 import org.wso2.carbon.identity.event.publisher.api.model.common.Subject;
-import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.identity.webhook.common.event.handler.api.model.EventData;
 import org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata;
 import org.wso2.identity.webhook.common.event.handler.api.service.EventProfileManager;
@@ -297,26 +296,6 @@ public class EventHookHandlerUtils {
 
         return SimpleSubject.createOpaqueSubject(streamId);
 
-    }
-
-    /**
-     * Resolves the immediate parent tenant domain of the current organization.
-     *
-     * @return Parent tenant domain if exists, otherwise null.
-     * @throws OrganizationManagementException If an error occurs while resolving the parent tenant domain.
-     */
-    public static String resolveParentTenantDomain() throws OrganizationManagementException {
-
-        IdentityContext identityContext = IdentityContext.getThreadLocalIdentityContext();
-        if (identityContext.getOrganization() != null) {
-            String parentOrganizationId = identityContext.getOrganization().getParentOrganizationId();
-            if (parentOrganizationId != null) {
-                log.debug("Resolving parent tenant domain for organization: " + parentOrganizationId);
-                return EventHookHandlerDataHolder.getInstance()
-                        .getOrganizationManager().resolveTenantDomain(parentOrganizationId);
-            }
-        }
-        return null;
     }
 
     /**

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/EventHookHandlerUtils.java
@@ -46,9 +46,6 @@ import org.wso2.carbon.identity.event.publisher.api.model.common.ComplexSubject;
 import org.wso2.carbon.identity.event.publisher.api.model.common.SimpleSubject;
 import org.wso2.carbon.identity.event.publisher.api.model.common.Subject;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.PolicyEnum;
-import org.wso2.carbon.identity.webhook.metadata.api.exception.WebhookMetadataException;
-import org.wso2.carbon.identity.webhook.metadata.api.model.WebhookMetadataProperties;
 import org.wso2.identity.webhook.common.event.handler.api.model.EventData;
 import org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata;
 import org.wso2.identity.webhook.common.event.handler.api.service.EventProfileManager;
@@ -57,7 +54,6 @@ import org.wso2.identity.webhook.common.event.handler.internal.constant.Constant
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -321,23 +317,6 @@ public class EventHookHandlerUtils {
             }
         }
         return null;
-    }
-
-    /**
-     * Checks if the parent policy of the given tenant domain is immediate existing and future organizations.
-     *
-     * @param parentTenantDomain Parent tenant domain.
-     * @return True if the parent policy is immediate existing and future organizations, otherwise false.
-     * @throws WebhookMetadataException If an error occurs while retrieving webhook metadata properties.
-     */
-    public static boolean isParentPolicyImmediateOrgs(String parentTenantDomain) throws WebhookMetadataException {
-
-        WebhookMetadataProperties metadataProperties =
-                EventHookHandlerDataHolder.getInstance().getWebhookMetadataService()
-                        .getWebhookMetadataProperties(parentTenantDomain);
-        return metadataProperties != null &&
-                Objects.equals(metadataProperties.getOrganizationPolicy().getPolicyCode(),
-                        PolicyEnum.IMMEDIATE_EXISTING_AND_FUTURE_ORGS.getPolicyCode());
     }
 
     /**


### PR DESCRIPTION
### Proposed changes in this pull request


This pull request makes a small cleanup to the `EventHookHandlerUtils.java` file by removing unused imports and a redundant method. These changes help keep the codebase clean and maintainable.

- Removed unused imports:
  - `PolicyEnum`, `WebhookMetadataException`, `WebhookMetadataProperties`, and `Objects` are no longer imported as they are not used in the file. [[1]](diffhunk://#diff-cab9d7e2a93d166dd0f253b0b38403872efa6e82c24fcf08a9e42efae611ad10L49-L51) [[2]](diffhunk://#diff-cab9d7e2a93d166dd0f253b0b38403872efa6e82c24fcf08a9e42efae611ad10L60)
- Removed the unused method `isParentPolicyImmediateOrgs`, which checked the parent policy of a tenant domain but was not referenced anywhere else in the codebase.