### PR TITLE
Remove unnecessary fetch-depth and token configuration from sync workflow

### DIFF
--- a/.github/workflows/sync-master-to-next.yml
+++ b/.github/workflows/sync-master-to-next.yml
@@ -24,9 +24,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ env.GH_TOKEN }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request makes a minor update to the GitHub Actions workflow configuration by removing some options from the repository checkout step.

* The `fetch-depth: 0` and `token: ${{ env.GH_TOKEN }}` options were removed from the `actions/checkout@v4` step in `.github/workflows/sync-master-to-next.yml`.