### PR TITLE
Refactor sync workflow: change trigger to push events, update commit retrieval method, and simplify PR body

### DIFF
--- a/.github/workflows/sync-master-to-next.yml
+++ b/.github/workflows/sync-master-to-next.yml
@@ -1,8 +1,7 @@
 name: 🔄 Sync master to next
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [master, main]
 
 permissions:
@@ -32,13 +31,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PR_AUTOMATION_BOT_TOKEN }}
         run: |
-          SYNC_BRANCH="sync-to-${{ env.TARGET_BRANCH }}-${{ github.run_id }}"
-          PR_NUMBER=${{ github.event.pull_request.number }}
+          SYNC_BRANCH="sync-${{ github.run_id }}-to-${{ env.TARGET_BRANCH }}"
+          BASE_BRANCH=${{ github.ref_name }}
 
           git fetch --all
           git checkout -b "$SYNC_BRANCH" "origin/${{ env.TARGET_BRANCH }}"
 
-          COMMITS=$(gh pr view $PR_NUMBER --json commits --jq '.commits[].oid' | tac)
+          # Get commits from the latest push
+          COMMITS=$(git log "origin/${{ env.TARGET_BRANCH }}..${BASE_BRANCH}" --pretty=format:"%H")
 
           echo "Cherry-picking commits..."
           CONFLICTS=false
@@ -63,11 +63,9 @@ jobs:
 
           git push origin "$SYNC_BRANCH"
 
-          PR_BODY="🤖 **Auto-sync from ${{ github.event.pull_request.base.ref }}**
-          This PR automatically syncs the changes from #${{ github.event.pull_request.number }} to the \`${{ env.TARGET_BRANCH }}\` branch.
+          PR_BODY="🤖 **Auto-sync from ${BASE_BRANCH}**
+          This PR automatically syncs the latest changes from \`${BASE_BRANCH}\` to the \`${{ env.TARGET_BRANCH }}\` branch.
 
-          **Original PR:** ${{ github.event.pull_request.html_url }}
-          **Author:** @${{ github.event.pull_request.user.login }}
           **Workflow:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           if [ "$CONFLICTS" = true ]; then
@@ -77,16 +75,8 @@ jobs:
           This PR requires manual resolution of merge conflicts."
           fi
 
-          PR_BODY="$PR_BODY
-
-          ---
-
-          ${{ github.event.pull_request.body }}"
-
           gh pr create \
             --base "${{ env.TARGET_BRANCH }}" \
             --head "$SYNC_BRANCH" \
-            --title "[Sync][${{ github.event.pull_request.base.ref }} -> ${{
-              env.TARGET_BRANCH }}][#${{ github.event.pull_request.number }}]: ${{ github.event.pull_request.title }}" \
-            --body "$PR_BODY" \
-            --reviewer "${{ github.event.pull_request.user.login }}"
+            --title "[Sync][${BASE_BRANCH} -> ${{ env.TARGET_BRANCH }}]: Auto-sync" \
+            --body "$PR_BODY"


### PR DESCRIPTION
### Proposed changes in this pull request
This pull request updates the workflow that syncs changes from the `master` or `main` branch to the `next` branch. The workflow is now triggered by pushes to `master` or `main`, rather than closed pull requests, and the sync logic has been refactored to cherry-pick commits directly from the latest push. The pull request creation step has also been simplified, removing references to the original PR and its author.

**Workflow trigger and logic changes:**

* The workflow `.github/workflows/sync-master-to-next.yml` now triggers on pushes to the `master` or `main` branches instead of closed pull requests, ensuring more reliable and immediate syncing.

**Cherry-pick and commit selection improvements:**

* The commit selection logic has been updated to cherry-pick all commits from the latest push to `master`/`main` that are not yet in the target branch, using `git log` instead of GitHub PR metadata.

**Pull request creation and messaging simplification:**

* The auto-sync pull request body and title have been simplified to reference only the source and target branches, removing details about the original PR and its author for clarity. [[1]](diffhunk://#diff-d723aca01e3ac7c7c4520fece89c33b8d69fae10704f6e8024b4f1dd108d87f3L66-L70) [[2]](diffhunk://#diff-d723aca01e3ac7c7c4520fece89c33b8d69fae10704f6e8024b4f1dd108d87f3L80-R82)