### PR TITLE
Fix ignoring claims updating with empty values

### DIFF
--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/UserClaim.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/UserClaim.java
@@ -18,12 +18,15 @@
 
 package org.wso2.identity.webhook.wso2.event.handler.internal.model.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * User claim class.
  */
 public class UserClaim {
 
     private String uri;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Object value;
 
     public UserClaim(Builder builder) {

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/util/WSO2PayloadUtils.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/util/WSO2PayloadUtils.java
@@ -281,7 +281,7 @@ public class WSO2PayloadUtils {
 
     public static Optional<UserClaim> generateUserClaim(String claimKey, String claimValue, String tenantDomain) {
 
-        if (StringUtils.isBlank(claimKey) || StringUtils.isBlank(claimValue)) {
+        if (StringUtils.isBlank(claimKey) || claimValue == null) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
### Proposed changes in this pull request
- When a user claim is updated to a `""` or a `[]`, the webook payload builder silently drops the updating claim information, which is leading to event fire with misleading data.
- So this PR will allow having empty values for the claim value field, so the json serializer doesn't drop them when building the API payload.

### Related issue
-  https://github.com/wso2/product-is/issues/28071