### PR TITLE
Remove subjectId from revokeConsent webhook payload

### DIFF
--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2ConsentEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2ConsentEventPayloadBuilder.java
@@ -277,7 +277,6 @@ public class WSO2ConsentEventPayloadBuilder implements ConsentEventPayloadBuilde
                             .purpose(purpose)
                             .build();
                     payloads.add(new WSO2ConsentRevokedEventPayload.Builder()
-                            .subjectId(subjectId)
                             .consent(consent)
                             .tenant(tenant)
                             .organization(organization)

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2ConsentRevokedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2ConsentRevokedEventPayload.java
@@ -31,12 +31,10 @@ import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.UserSt
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WSO2ConsentRevokedEventPayload extends WSO2BaseEventPayload {
 
-    private final String subjectId;
     private final Consent consent;
 
     private WSO2ConsentRevokedEventPayload(Builder builder) {
 
-        this.subjectId = builder.subjectId;
         this.consent = builder.consent;
         this.tenant = builder.tenant;
         this.organization = builder.organization;
@@ -47,11 +45,6 @@ public class WSO2ConsentRevokedEventPayload extends WSO2BaseEventPayload {
         this.initiatorIpAddress = builder.initiatorIpAddress;
     }
 
-    public String getSubjectId() {
-
-        return subjectId;
-    }
-
     public Consent getConsent() {
 
         return consent;
@@ -59,7 +52,6 @@ public class WSO2ConsentRevokedEventPayload extends WSO2BaseEventPayload {
 
     public static class Builder {
 
-        private String subjectId;
         private Consent consent;
         private Tenant tenant;
         private Organization organization;
@@ -68,12 +60,6 @@ public class WSO2ConsentRevokedEventPayload extends WSO2BaseEventPayload {
         private String action;
         private String initiatorType;
         private String initiatorIpAddress;
-
-        public Builder subjectId(String subjectId) {
-
-            this.subjectId = subjectId;
-            return this;
-        }
 
         public Builder consent(Consent consent) {
 


### PR DESCRIPTION
This pull request removes the `subjectId` field from the `WSO2ConsentRevokedEventPayload` class and updates related code to reflect this change. This simplifies the event payload structure by eliminating an unused or redundant field.

**Refactoring and Simplification:**

* Removed the `subjectId` field and its associated getter from the `WSO2ConsentRevokedEventPayload` class, as well as the corresponding builder method. [[1]](diffhunk://#diff-4bb1f2bb48e1fbf01193c4fc2fe88b6b9680f38d4deb875e722af6cc7f5a28c7L34-L39) [[2]](diffhunk://#diff-4bb1f2bb48e1fbf01193c4fc2fe88b6b9680f38d4deb875e722af6cc7f5a28c7L50-L62) [[3]](diffhunk://#diff-4bb1f2bb48e1fbf01193c4fc2fe88b6b9680f38d4deb875e722af6cc7f5a28c7L72-L77)
* Updated the event payload builder logic to no longer set the `subjectId` when constructing `WSO2ConsentRevokedEventPayload` instances.