### PR TITLE
Fix unit test issue

### DIFF
--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/internal/service/impl/WSO2EventProfileManagerTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/internal/service/impl/WSO2EventProfileManagerTest.java
@@ -99,25 +99,29 @@ public class WSO2EventProfileManagerTest {
     @DataProvider(name = "consentEventDataProvider")
     public Object[][] consentEventDataProvider() {
 
-        // eventName, currentFlowName (null means no active flow), expectedChannel, expectedEvent.
+        // eventName, currentFlowName (null means no active flow), initiatingPersona, expectedChannel, expectedEvent.
         return new Object[][]{
-                {POST_ADD_RECEIPT, null, CONSENT_CHANNEL, CONSENT_ADDED_EVENT},
-                {POST_ADD_PURPOSE_VERSION, null, CONSENT_PURPOSE_CHANNEL, CONSENT_PURPOSE_VERSION_ADDED_EVENT},
+                {POST_ADD_RECEIPT, null, null, CONSENT_CHANNEL, CONSENT_ADDED_EVENT},
+                {POST_ADD_PURPOSE_VERSION, null, null, CONSENT_PURPOSE_CHANNEL, CONSENT_PURPOSE_VERSION_ADDED_EVENT},
                 // authorizeConsent publishes a single POST_AUTHORIZE_CONSENT event; the active flow decides the type.
-                {POST_AUTHORIZE_CONSENT, Flow.Name.CONSENT_ACCEPT, CONSENT_CHANNEL, CONSENT_ADDED_EVENT},
-                {POST_AUTHORIZE_CONSENT, Flow.Name.CONSENT_REJECT, CONSENT_CHANNEL, CONSENT_ADDED_EVENT},
-                {POST_AUTHORIZE_CONSENT, Flow.Name.CONSENT_REVOKE, CONSENT_CHANNEL, CONSENT_REVOKED_EVENT},
-                {POST_AUTHORIZE_CONSENT, null, CONSENT_CHANNEL, CONSENT_ADDED_EVENT}
+                {POST_AUTHORIZE_CONSENT, Flow.Name.CONSENT_CREATE, Flow.InitiatingPersona.ADMIN, CONSENT_CHANNEL,
+                        CONSENT_ADDED_EVENT},
+                {POST_AUTHORIZE_CONSENT, Flow.Name.CONSENT_GRANT, Flow.InitiatingPersona.USER, CONSENT_CHANNEL,
+                        CONSENT_ADDED_EVENT},
+                {POST_AUTHORIZE_CONSENT, Flow.Name.CONSENT_REVOKE, Flow.InitiatingPersona.USER, CONSENT_CHANNEL,
+                        CONSENT_REVOKED_EVENT},
+                {POST_AUTHORIZE_CONSENT, null, null, CONSENT_CHANNEL, CONSENT_ADDED_EVENT}
         };
     }
 
     @Test(dataProvider = "consentEventDataProvider")
     public void testResolveEventMetadataForConsentEvents(String eventName, Flow.Name currentFlowName,
+                                                         Flow.InitiatingPersona initiatingPersona,
                                                          String expectedChannel, String expectedEvent) {
 
         Flow flow = (currentFlowName == null) ? null : new Flow.Builder()
                 .name(currentFlowName)
-                .initiatingPersona(Flow.InitiatingPersona.USER)
+                .initiatingPersona(initiatingPersona)
                 .build();
         Mockito.when(mockIdentityContext.getCurrentFlow()).thenReturn(flow);
 

--- a/pom.xml
+++ b/pom.xml
@@ -499,7 +499,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.11.143</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.150</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
This pull request updates the test data and logic for consent event handling in `WSO2EventProfileManagerTest` and bumps the Carbon Identity Framework version in the project dependencies. The changes improve the test coverage for consent events by introducing the `initiatingPersona` parameter and updating the corresponding test logic.

**Test improvements:**

* Updated the `consentEventDataProvider` to include the `initiatingPersona` parameter, allowing more accurate and comprehensive testing of consent event scenarios.
* Modified the `testResolveEventMetadataForConsentEvents` method to use the `initiatingPersona` from the data provider, ensuring that the correct persona is used when constructing test flows.

**Dependency updates:**

* Bumped the `carbon.identity.framework.version` from `7.11.143` to `7.11.150` in `pom.xml` to use the latest compatible version of the Carbon Identity Framework.