### PR TITLE
Publish role management events to webhooks

### DIFF
--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/builder/RoleManagementEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/builder/RoleManagementEventPayloadBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.common.event.handler.api.builder;
+
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
+import org.wso2.identity.webhook.common.event.handler.api.constants.Constants;
+import org.wso2.identity.webhook.common.event.handler.api.model.EventData;
+
+/**
+ * Interface for Role Management Event Payload Builders.
+ */
+public interface RoleManagementEventPayloadBuilder {
+
+    /**
+     * Build the payload for a role-created event.
+     *
+     * @param eventData Event data from the Carbon event.
+     * @return EventPayload for the roleCreated webhook event.
+     * @throws IdentityEventException if payload building fails.
+     */
+    EventPayload buildRoleCreatedEvent(EventData eventData) throws IdentityEventException;
+
+    /**
+     * Build the payload for a role-meta-updated event (name change and other metadata mutations).
+     *
+     * @param eventData Event data from the Carbon event.
+     * @return EventPayload for the roleMetaUpdated webhook event.
+     * @throws IdentityEventException if payload building fails.
+     */
+    EventPayload buildRoleMetaUpdatedEvent(EventData eventData) throws IdentityEventException;
+
+    /**
+     * Build the payload for a role-deleted event.
+     *
+     * @param eventData Event data from the Carbon event.
+     * @return EventPayload for the roleDeleted webhook event.
+     * @throws IdentityEventException if payload building fails.
+     */
+    EventPayload buildRoleDeletedEvent(EventData eventData) throws IdentityEventException;
+
+    /**
+     * Build the payload for a role user-list updated event.
+     *
+     * @param eventData Event data from the Carbon event.
+     * @return EventPayload for the roleUsersUpdated webhook event.
+     * @throws IdentityEventException if payload building fails.
+     */
+    EventPayload buildRoleUsersUpdatedEvent(EventData eventData) throws IdentityEventException;
+
+    /**
+     * Build the payload for a role group-list updated event.
+     *
+     * @param eventData Event data from the Carbon event.
+     * @return EventPayload for the roleGroupsUpdated webhook event.
+     * @throws IdentityEventException if payload building fails.
+     */
+    EventPayload buildRoleGroupsUpdatedEvent(EventData eventData) throws IdentityEventException;
+
+    /**
+     * Build the payload for a role IdP-group-list updated event.
+     *
+     * @param eventData Event data from the Carbon event.
+     * @return EventPayload for the roleIdpGroupsUpdated webhook event.
+     * @throws IdentityEventException if payload building fails.
+     */
+    EventPayload buildRoleIdpGroupsUpdatedEvent(EventData eventData) throws IdentityEventException;
+
+    /**
+     * Build the payload for a role permissions updated event.
+     *
+     * @param eventData Event data from the Carbon event.
+     * @return EventPayload for the rolePermissionsUpdated webhook event.
+     * @throws IdentityEventException if payload building fails.
+     */
+    EventPayload buildRolePermissionsUpdatedEvent(EventData eventData) throws IdentityEventException;
+
+    /**
+     * Return the event schema type this builder implements.
+     *
+     * @return Event schema type.
+     */
+    Constants.EventSchema getEventSchemaType();
+}

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/constants/Constants.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/api/constants/Constants.java
@@ -48,6 +48,7 @@ public class Constants {
         public static final String VERIFICATION_CHANNEL = "https://schemas.identity.wso2.org/events/verification";
         public static final String SESSION_CHANNEL = "https://schemas.identity.wso2.org/events/session";
         public static final String TOKEN_CHANNEL = "https://schemas.identity.wso2.org/events/token";
+        public static final String ROLE_MANAGEMENT_CHANNEL = "https://schemas.identity.wso2.org/events/role";
     }
 
     /**
@@ -73,5 +74,31 @@ public class Constants {
         public static final String SESSION_PRESENTED_EVENT = "https://schemas.identity.wso2.org/events/session/event-type/sessionPresented";
         public static final String TOKEN_ISSUED_EVENT = "https://schemas.identity.wso2.org/events/token/event-type/accessTokenIssued";
         public static final String TOKEN_REVOKED_EVENT = "https://schemas.identity.wso2.org/events/token/event-type/accessTokenRevoked";
+        public static final String ROLE_CREATED_EVENT =
+                "https://schemas.identity.wso2.org/events/role/event-type/roleCreated";
+        public static final String ROLE_META_UPDATED_EVENT =
+                "https://schemas.identity.wso2.org/events/role/event-type/roleMetaUpdated";
+        public static final String ROLE_DELETED_EVENT =
+                "https://schemas.identity.wso2.org/events/role/event-type/roleDeleted";
+        public static final String ROLE_USERS_UPDATED_EVENT =
+                "https://schemas.identity.wso2.org/events/role/event-type/roleUsersUpdated";
+        public static final String ROLE_GROUPS_UPDATED_EVENT =
+                "https://schemas.identity.wso2.org/events/role/event-type/roleGroupsUpdated";
+        public static final String ROLE_IDP_GROUPS_UPDATED_EVENT =
+                "https://schemas.identity.wso2.org/events/role/event-type/roleIdpGroupsUpdated";
+        public static final String ROLE_PERMISSIONS_UPDATED_EVENT =
+                "https://schemas.identity.wso2.org/events/role/event-type/rolePermissionsUpdated";
+    }
+
+    /**
+     * This class represents role management event handler configuration keys.
+     */
+    public static class RoleManagement {
+
+        public static final int ROLE_LIST_MAX_SIZE = 1000;
+
+        private RoleManagement() {
+
+        }
     }
 }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/component/EventHookHandlerDataHolder.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/component/EventHookHandlerDataHolder.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.flow.mgt.FlowMgtService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManagementService;
 import org.wso2.carbon.identity.webhook.metadata.api.service.WebhookMetadataService;
+import org.wso2.identity.webhook.common.event.handler.api.builder.RoleManagementEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.TokenEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.service.EventProfileManager;
 import org.wso2.identity.webhook.common.event.handler.api.builder.CredentialEventPayloadBuilder;
@@ -60,6 +61,7 @@ public class EventHookHandlerDataHolder {
     private final List<VerificationEventPayloadBuilder> verificationEventPayloadBuilders = new ArrayList<>();
     private final List<RegistrationEventPayloadBuilder> registrationEventPayloadBuilders = new ArrayList<>();
     private final List<TokenEventPayloadBuilder> tokenEventPayloadBuilders = new ArrayList<>();
+    private final List<RoleManagementEventPayloadBuilder> roleManagementEventPayloadBuilders = new ArrayList<>();
 
     private EventHookHandlerDataHolder() {
 
@@ -439,5 +441,37 @@ public class EventHookHandlerDataHolder {
     public void setOrganizationManager(OrganizationManager organizationManager) {
 
         this.organizationManager = organizationManager;
+    }
+
+    /**
+     * Get the list of role management event payload builder implementations available.
+     *
+     * @return List of role management event payload builder implementations.
+     */
+    public List<RoleManagementEventPayloadBuilder> getRoleManagementEventPayloadBuilders() {
+
+        return roleManagementEventPayloadBuilders;
+    }
+
+    /**
+     * Add a role management event payload builder implementation.
+     *
+     * @param roleManagementEventPayloadBuilder Role management event payload builder implementation.
+     */
+    public void addRoleManagementEventPayloadBuilder(
+            RoleManagementEventPayloadBuilder roleManagementEventPayloadBuilder) {
+
+        roleManagementEventPayloadBuilders.add(roleManagementEventPayloadBuilder);
+    }
+
+    /**
+     * Remove a role management event payload builder implementation.
+     *
+     * @param roleManagementEventPayloadBuilder Role management event payload builder implementation.
+     */
+    public void removeRoleManagementEventPayloadBuilder(
+            RoleManagementEventPayloadBuilder roleManagementEventPayloadBuilder) {
+
+        roleManagementEventPayloadBuilders.remove(roleManagementEventPayloadBuilder);
     }
 }

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/component/EventHookHandlerServiceComponent.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/component/EventHookHandlerServiceComponent.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.event.publisher.api.service.EventPublisherServic
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.topic.management.api.service.TopicManagementService;
 import org.wso2.carbon.identity.webhook.metadata.api.service.WebhookMetadataService;
+import org.wso2.identity.webhook.common.event.handler.api.builder.RoleManagementEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.TokenEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.service.EventProfileManager;
 import org.wso2.identity.webhook.common.event.handler.api.builder.CredentialEventPayloadBuilder;
@@ -53,6 +54,7 @@ import org.wso2.identity.webhook.common.event.handler.internal.constant.Constant
 import org.wso2.identity.webhook.common.event.handler.internal.handler.CredentialEventHookHandler;
 import org.wso2.identity.webhook.common.event.handler.internal.handler.LoginEventHookHandler;
 import org.wso2.identity.webhook.common.event.handler.internal.handler.RegistrationEventHookHandler;
+import org.wso2.identity.webhook.common.event.handler.internal.handler.RoleManagementEventHookHandler;
 import org.wso2.identity.webhook.common.event.handler.internal.handler.SessionEventHookHandler;
 import org.wso2.identity.webhook.common.event.handler.internal.handler.TokenEventHookHandler;
 import org.wso2.identity.webhook.common.event.handler.internal.handler.UserOperationEventHookHandler;
@@ -119,6 +121,15 @@ public class EventHookHandlerServiceComponent {
             if (isTokenEventHandlerEnabled != null && isTokenEventHandlerEnabled
                     .equalsIgnoreCase(Boolean.TRUE.toString())) {
                 bundleContext.registerService(AbstractEventHandler.class.getName(), new TokenEventHookHandler(), null);
+            }
+
+            String isRoleManagementEventHandlerEnabled =
+                    getIdentityEventProperty(Constants.ROLE_MANAGEMENT_EVENT_HOOK_NAME,
+                            Constants.ROLE_MANAGEMENT_EVENT_HOOK_ENABLED);
+            if (isRoleManagementEventHandlerEnabled != null && isRoleManagementEventHandlerEnabled
+                    .equalsIgnoreCase(Boolean.TRUE.toString())) {
+                bundleContext.registerService(AbstractEventHandler.class.getName(),
+                        new RoleManagementEventHookHandler(), null);
             }
         } catch (IdentityEventServerException e) {
             log.error("Error while activating event handler.", e);
@@ -434,6 +445,33 @@ public class EventHookHandlerServiceComponent {
         log.debug("Remove Token Event Payload Builder service " + tokenEventPayloadBuilder.getEventSchemaType());
         EventHookHandlerDataHolder.getInstance().removeTokenEventPayloadBuilder(tokenEventPayloadBuilder);
     }
+
+    @Reference(
+            name = "role.management.event.payload.builder",
+            service = RoleManagementEventPayloadBuilder.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "removeRoleManagementEventPayloadBuilder"
+    )
+    protected void addRoleManagementEventPayloadBuilder(
+            RoleManagementEventPayloadBuilder roleManagementEventPayloadBuilder) {
+
+        log.debug("Add Role Management Event Payload Builder service " +
+                roleManagementEventPayloadBuilder.getEventSchemaType());
+        EventHookHandlerDataHolder.getInstance()
+                .addRoleManagementEventPayloadBuilder(roleManagementEventPayloadBuilder);
+    }
+
+    protected void removeRoleManagementEventPayloadBuilder(
+            RoleManagementEventPayloadBuilder roleManagementEventPayloadBuilder) {
+
+        log.debug("Remove Role Management Event Payload Builder service " +
+                roleManagementEventPayloadBuilder.getEventSchemaType());
+        EventHookHandlerDataHolder.getInstance()
+                .removeRoleManagementEventPayloadBuilder(roleManagementEventPayloadBuilder);
+    }
+
+
     /**
      * Get the identity property specified in identity-event.properties.
      *

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/constant/Constants.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/constant/Constants.java
@@ -47,6 +47,10 @@ public class Constants {
     public static final String TOKEN_EVENT_HOOK_NAME = "TokenEventHook";
     public static final String TOKEN_EVENT_HOOK_ENABLED = "TokenEventHook.enable";
 
+    public static final String ROLE_MANAGEMENT_EVENT_HOOK_NAME = "RoleManagementEventHook";
+    public static final String ROLE_MANAGEMENT_EVENT_HOOK_ENABLED = "RoleManagementEventHook.enable";
+
+
     public static final String SKIP_SIGNUP_CONFIRMATION_IF_ACCOUNT_LOCK_DISABLED =
             "Webhooks.Registration.SkipSignupConfirmationIfAccountLockDisabled";
 

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RoleManagementEventHookHandler.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RoleManagementEventHookHandler.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.common.event.handler.internal.handler;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Organization;
+import org.wso2.carbon.identity.core.context.model.RootOrganization;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.bean.IdentityEventMessageContext;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.event.publisher.api.exception.EventPublisherException;
+import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
+import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
+import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.webhook.metadata.api.model.Channel;
+import org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile;
+import org.wso2.identity.webhook.common.event.handler.api.builder.RoleManagementEventPayloadBuilder;
+import org.wso2.identity.webhook.common.event.handler.api.constants.Constants;
+import org.wso2.identity.webhook.common.event.handler.api.model.EventData;
+import org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata;
+import org.wso2.identity.webhook.common.event.handler.internal.component.EventHookHandlerDataHolder;
+import org.wso2.identity.webhook.common.event.handler.internal.util.EventHookHandlerUtils;
+import org.wso2.identity.webhook.common.event.handler.internal.util.PayloadBuilderFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.wso2.identity.webhook.common.event.handler.internal.constant.Constants.EVENT_PROFILE_VERSION;
+import static org.wso2.identity.webhook.common.event.handler.internal.constant.Constants.ROLE_MANAGEMENT_EVENT_HOOK_NAME;
+
+/**
+ * Role Management Event Hook Handler.
+ * Subscribes to V2 role lifecycle Carbon events and publishes them as webhook events.
+ */
+public class RoleManagementEventHookHandler extends AbstractEventHandler {
+
+    private static final Log LOG = LogFactory.getLog(RoleManagementEventHookHandler.class);
+
+    @Override
+    public String getName() {
+
+        return ROLE_MANAGEMENT_EVENT_HOOK_NAME;
+    }
+
+    @Override
+    public boolean canHandle(MessageContext messageContext) throws IdentityRuntimeException {
+
+        try {
+            if (!(messageContext instanceof IdentityEventMessageContext identityContext)) {
+                LOG.debug("MessageContext is not of type IdentityEventMessageContext. Cannot handle the event.");
+                return false;
+            }
+            String eventName = identityContext.getEvent() != null ? identityContext.getEvent().getEventName() : null;
+            if (eventName == null) {
+                LOG.debug("Event name is null in IdentityEventMessageContext. Cannot handle the event.");
+                return false;
+            }
+            boolean canHandle = isSupportedEvent(eventName) && !isAccessingSubOrganization();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(eventName + (canHandle ? " event can be handled." : " event cannot be handled."));
+            }
+            return canHandle;
+        } catch (Exception e) {
+            LOG.warn("Unexpected error occurred while evaluating event in RoleManagementEventHookHandler.", e);
+            return false;
+        }
+    }
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        try {
+            List<EventProfile> eventProfileList =
+                    EventHookHandlerDataHolder.getInstance().getWebhookMetadataService().getSupportedEventProfiles();
+            if (eventProfileList.isEmpty()) {
+                LOG.warn("No event profiles found in the webhook metadata service. " +
+                        "Skipping role management event handling.");
+                return;
+            }
+            for (EventProfile eventProfile : eventProfileList) {
+                handleEventPerProfile(event, eventProfile);
+            }
+        } catch (Exception e) {
+            LOG.warn("Error while handling role management event: " + event.getEventName(), e);
+        }
+    }
+
+    private void handleEventPerProfile(Event event, EventProfile eventProfile)
+            throws IdentityEventException, EventPublisherException {
+
+        Constants.EventSchema schema =
+                Constants.EventSchema.valueOf(eventProfile.getProfile());
+        RoleManagementEventPayloadBuilder payloadBuilder =
+                PayloadBuilderFactory.getRoleManagementEventPayloadBuilder(schema);
+        if (payloadBuilder == null) {
+            LOG.debug("Skipping role management event handling for profile " + eventProfile.getProfile());
+            return;
+        }
+        EventMetadata eventMetadata =
+                EventHookHandlerUtils.getEventProfileManagerByProfile(eventProfile.getProfile(), event.getEventName());
+        if (eventMetadata == null) {
+            LOG.debug("No event metadata found for event: " + event.getEventName() +
+                    " in profile: " + eventProfile.getProfile());
+            return;
+        }
+        EventData eventData = EventHookHandlerUtils.buildEventDataProvider(event);
+        String tenantDomain = eventData.getTenantDomain();
+
+        Channel roleChannel = eventProfile.getChannels().stream()
+                .filter(channel -> eventMetadata.getChannel().equals(channel.getUri()))
+                .findFirst()
+                .orElse(null);
+        if (roleChannel == null) {
+            LOG.debug("No channel found for role management event profile: " + eventProfile.getProfile());
+            return;
+        }
+        String eventUri = roleChannel.getEvents().stream()
+                .filter(channelEvent -> Objects.equals(eventMetadata.getEvent(), channelEvent.getEventUri()))
+                .findFirst()
+                .map(org.wso2.carbon.identity.webhook.metadata.api.model.Event::getEventUri)
+                .orElse(null);
+
+        publishRoleManagementEvent(tenantDomain, roleChannel, eventUri, eventProfile.getProfile(),
+                payloadBuilder, eventData, event.getEventName());
+    }
+
+    /**
+     * Returns true when the thread-local identity context is scoped to a sub-organization, i.e. the currently
+     * accessed organization is not the root of the hierarchy.
+     *
+     * NOTE: EventHookHandlerUtils.isSubOrgLevel() (commit a9effd43) compares org.id == org.parentOrganizationId,
+     * which is never true for any real organization and therefore always returns false. That helper is left
+     * unchanged to avoid side-effects on TokenEventHookHandler; this local check is used instead.
+     */
+    private static boolean isAccessingSubOrganization() throws IdentityEventException {
+
+        IdentityContext ctx = IdentityContext.getThreadLocalIdentityContext();
+        String tenantDomain = ctx.getTenantDomain();
+        try {
+            if (tenantDomain != null && OrganizationManagementUtil.isOrganization(tenantDomain)) {
+                LOG.debug("Accessing sub organization: " + ctx.getTenantDomain() + " (root organization is null)");
+                return true;
+            }
+        } catch (OrganizationManagementException e) {
+            throw new IdentityEventException(
+                    "Error while checking if the tenant domain is a sub-organization: " + tenantDomain, e);
+        }
+        return false;
+    }
+
+    private boolean isSupportedEvent(String eventName) {
+
+        return IdentityEventConstants.Event.POST_ADD_ROLE_V2_EVENT.equals(eventName) ||
+                IdentityEventConstants.Event.POST_UPDATE_ROLE_V2_NAME_EVENT.equals(eventName) ||
+                IdentityEventConstants.Event.POST_DELETE_ROLE_V2_EVENT.equals(eventName) ||
+                IdentityEventConstants.Event.POST_UPDATE_USER_LIST_OF_ROLE_V2_EVENT.equals(eventName) ||
+                IdentityEventConstants.Event.POST_UPDATE_GROUP_LIST_OF_ROLE_V2_EVENT.equals(eventName) ||
+                IdentityEventConstants.Event.POST_UPDATE_IDP_GROUP_LIST_OF_ROLE_V2_EVENT.equals(eventName) ||
+                IdentityEventConstants.Event.POST_UPDATE_PERMISSIONS_FOR_ROLE_V2_EVENT.equals(eventName);
+    }
+
+    private void publishRoleManagementEvent(String tenantDomain, Channel roleChannel, String eventUri,
+                                            String eventProfileName, RoleManagementEventPayloadBuilder payloadBuilder,
+                                            EventData eventData, String eventName)
+            throws IdentityEventException, EventPublisherException {
+
+        EventContext eventContext = EventContext.builder()
+                .tenantDomain(tenantDomain)
+                .eventUri(roleChannel.getUri())
+                .eventProfileName(eventProfileName)
+                .eventProfileVersion(EVENT_PROFILE_VERSION)
+                .build();
+
+        EventPayload eventPayload;
+        if (IdentityEventConstants.Event.POST_ADD_ROLE_V2_EVENT.equals(eventName)) {
+            eventPayload = payloadBuilder.buildRoleCreatedEvent(eventData);
+        } else if (IdentityEventConstants.Event.POST_UPDATE_ROLE_V2_NAME_EVENT.equals(eventName)) {
+            eventPayload = payloadBuilder.buildRoleMetaUpdatedEvent(eventData);
+        } else if (IdentityEventConstants.Event.POST_DELETE_ROLE_V2_EVENT.equals(eventName)) {
+            eventPayload = payloadBuilder.buildRoleDeletedEvent(eventData);
+        } else if (IdentityEventConstants.Event.POST_UPDATE_USER_LIST_OF_ROLE_V2_EVENT.equals(eventName)) {
+            eventPayload = payloadBuilder.buildRoleUsersUpdatedEvent(eventData);
+        } else if (IdentityEventConstants.Event.POST_UPDATE_GROUP_LIST_OF_ROLE_V2_EVENT.equals(eventName)) {
+            eventPayload = payloadBuilder.buildRoleGroupsUpdatedEvent(eventData);
+        } else if (IdentityEventConstants.Event.POST_UPDATE_IDP_GROUP_LIST_OF_ROLE_V2_EVENT.equals(eventName)) {
+            eventPayload = payloadBuilder.buildRoleIdpGroupsUpdatedEvent(eventData);
+        } else if (IdentityEventConstants.Event.POST_UPDATE_PERMISSIONS_FOR_ROLE_V2_EVENT.equals(eventName)) {
+            eventPayload = payloadBuilder.buildRolePermissionsUpdatedEvent(eventData);
+        } else {
+            LOG.debug("Unsupported role management event: " + eventName);
+            return;
+        }
+
+        SecurityEventTokenPayload securityEventTokenPayload =
+                EventHookHandlerUtils.buildSecurityEventToken(eventPayload, eventUri);
+        if (!EventHookHandlerDataHolder.getInstance().getEventPublisherService().canHandleEvent(eventContext)) {
+            return;
+        }
+        EventHookHandlerDataHolder.getInstance().getEventPublisherService()
+                .publish(securityEventTokenPayload, eventContext);
+    }
+}

--- a/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/PayloadBuilderFactory.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/main/java/org/wso2/identity/webhook/common/event/handler/internal/util/PayloadBuilderFactory.java
@@ -21,6 +21,7 @@ package org.wso2.identity.webhook.common.event.handler.internal.util;
 import org.wso2.identity.webhook.common.event.handler.api.builder.CredentialEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.LoginEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.RegistrationEventPayloadBuilder;
+import org.wso2.identity.webhook.common.event.handler.api.builder.RoleManagementEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.SessionEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.TokenEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.UserOperationEventPayloadBuilder;
@@ -148,6 +149,26 @@ public class PayloadBuilderFactory {
         for (TokenEventPayloadBuilder tokenEventPayloadBuilder : tokenEventPayloadBuilders) {
             if (tokenEventPayloadBuilder.getEventSchemaType().equals(eventSchemaType)) {
                 return tokenEventPayloadBuilder;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the role management event payload builder.
+     *
+     * @param eventSchemaType Event schema type.
+     * @return Role management event payload builder.
+     */
+    public static RoleManagementEventPayloadBuilder getRoleManagementEventPayloadBuilder(
+            Constants.EventSchema eventSchemaType) {
+
+        List<RoleManagementEventPayloadBuilder> roleManagementEventPayloadBuilders =
+                EventHookHandlerDataHolder.getInstance().getRoleManagementEventPayloadBuilders();
+        for (RoleManagementEventPayloadBuilder roleManagementEventPayloadBuilder :
+                roleManagementEventPayloadBuilders) {
+            if (roleManagementEventPayloadBuilder.getEventSchemaType().equals(eventSchemaType)) {
+                return roleManagementEventPayloadBuilder;
             }
         }
         return null;

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RoleManagementEventHookHandlerTest.java
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/java/org/wso2/identity/webhook/common/event/handler/internal/handler/RoleManagementEventHookHandlerTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.common.event.handler.internal.handler;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Organization;
+import org.wso2.carbon.identity.core.context.model.RootOrganization;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.bean.IdentityEventMessageContext;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.publisher.api.model.EventContext;
+import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
+import org.wso2.carbon.identity.event.publisher.api.model.SecurityEventTokenPayload;
+import org.wso2.carbon.identity.event.publisher.api.service.EventPublisherService;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.topic.management.api.service.TopicManagementService;
+import org.wso2.carbon.identity.webhook.metadata.api.model.Channel;
+import org.wso2.carbon.identity.webhook.metadata.api.model.EventProfile;
+import org.wso2.carbon.identity.webhook.metadata.api.service.WebhookMetadataService;
+import org.wso2.identity.webhook.common.event.handler.api.builder.RoleManagementEventPayloadBuilder;
+import org.wso2.identity.webhook.common.event.handler.api.model.EventData;
+import org.wso2.identity.webhook.common.event.handler.api.model.EventMetadata;
+import org.wso2.identity.webhook.common.event.handler.internal.component.EventHookHandlerDataHolder;
+import org.wso2.identity.webhook.common.event.handler.internal.constant.Constants;
+import org.wso2.identity.webhook.common.event.handler.internal.util.EventHookHandlerUtils;
+import org.wso2.identity.webhook.common.event.handler.internal.util.PayloadBuilderFactory;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.webhook.common.event.handler.util.TestUtils.closeMockedIdentityTenantUtil;
+import static org.wso2.identity.webhook.common.event.handler.util.TestUtils.closeMockedServiceURLBuilder;
+import static org.wso2.identity.webhook.common.event.handler.util.TestUtils.mockIdentityTenantUtil;
+import static org.wso2.identity.webhook.common.event.handler.util.TestUtils.mockServiceURLBuilder;
+
+/**
+ * Unit tests for {@link RoleManagementEventHookHandler}.
+ */
+public class RoleManagementEventHookHandlerTest {
+
+    private static final String ROLE_CHANNEL_URI = "https://schemas.identity.wso2.org/events/role";
+    private static final String ROLE_CREATED_EVENT_URI =
+            "https://schemas.identity.wso2.org/events/role/event-type/roleCreated";
+    private static final String CARBON_SUPER = "carbon.super";
+
+    @Mock
+    private EventPublisherService mockedEventPublisherService;
+    @Mock
+    private EventPayload mockedEventPayload;
+    @Mock
+    private RoleManagementEventPayloadBuilder mockedRoleManagementEventPayloadBuilder;
+    @Mock
+    private WebhookMetadataService mockedWebhookMetadataService;
+    @Mock
+    private TopicManagementService mockedTopicManagementService;
+
+    private RoleManagementEventHookHandler roleManagementEventHookHandler;
+
+    @BeforeClass
+    public void setupClass() throws IdentityEventException {
+
+        String carbonHome = Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString();
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, carbonHome);
+        MockitoAnnotations.openMocks(this);
+        setupDataHolderMocks();
+        setupPayloadBuilderMocks();
+        mockServiceURLBuilder();
+        mockIdentityTenantUtil();
+        roleManagementEventHookHandler = new RoleManagementEventHookHandler();
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        closeMockedServiceURLBuilder();
+        closeMockedIdentityTenantUtil();
+    }
+
+    @AfterMethod
+    public void tearDownMethod() {
+
+        Mockito.reset(mockedEventPublisherService);
+    }
+
+    @Test
+    public void testGetName() {
+
+        assertEquals(roleManagementEventHookHandler.getName(), Constants.ROLE_MANAGEMENT_EVENT_HOOK_NAME);
+    }
+
+    @DataProvider(name = "supportedEventsDataProvider")
+    public Object[][] supportedEventsDataProvider() {
+
+        return new Object[][]{
+                {IdentityEventConstants.Event.POST_ADD_ROLE_V2_EVENT},
+                {IdentityEventConstants.Event.POST_UPDATE_ROLE_V2_NAME_EVENT},
+                {IdentityEventConstants.Event.POST_DELETE_ROLE_V2_EVENT},
+                {IdentityEventConstants.Event.POST_UPDATE_USER_LIST_OF_ROLE_V2_EVENT},
+                {IdentityEventConstants.Event.POST_UPDATE_GROUP_LIST_OF_ROLE_V2_EVENT},
+                {IdentityEventConstants.Event.POST_UPDATE_IDP_GROUP_LIST_OF_ROLE_V2_EVENT},
+                {IdentityEventConstants.Event.POST_UPDATE_PERMISSIONS_FOR_ROLE_V2_EVENT}
+        };
+    }
+
+    @Test(dataProvider = "supportedEventsDataProvider")
+    public void testCanHandleSupportedEvents(String eventName) {
+
+        Event event = new Event(eventName);
+        IdentityEventMessageContext messageContext = new IdentityEventMessageContext(event);
+
+        try (MockedStatic<IdentityContext> identityContextMock = mockStatic(IdentityContext.class);
+             MockedStatic<OrganizationManagementUtil> orgUtilMock = mockStatic(OrganizationManagementUtil.class)) {
+            IdentityContext rootOrgCtx = mock(IdentityContext.class);
+            when(rootOrgCtx.getTenantDomain()).thenReturn(CARBON_SUPER);
+            identityContextMock.when(IdentityContext::getThreadLocalIdentityContext).thenReturn(rootOrgCtx);
+            orgUtilMock.when(() -> OrganizationManagementUtil.isOrganization(CARBON_SUPER)).thenReturn(false);
+
+            assertTrue(roleManagementEventHookHandler.canHandle(messageContext),
+                    "Handler should be able to handle event: " + eventName);
+        }
+    }
+
+    @DataProvider(name = "unsupportedEventsDataProvider")
+    public Object[][] unsupportedEventsDataProvider() {
+
+        return new Object[][]{
+                {IdentityEventConstants.Event.POST_UPDATE_USER_LIST_OF_ROLE_EVENT},
+                {IdentityEventConstants.Event.POST_ADD_ROLE_EVENT},
+                {IdentityEventConstants.Event.PRE_DELETE_ROLE_V2_EVENT},
+                {IdentityEventConstants.Event.POST_UNLOCK_ACCOUNT},
+                {IdentityEventConstants.Event.POST_UPDATE_CREDENTIAL}
+        };
+    }
+
+    @Test(dataProvider = "unsupportedEventsDataProvider")
+    public void testCannotHandleUnsupportedEvents(String eventName) {
+
+        Event event = new Event(eventName);
+        IdentityEventMessageContext messageContext = new IdentityEventMessageContext(event);
+        assertFalse(roleManagementEventHookHandler.canHandle(messageContext),
+                "Handler should NOT be able to handle event: " + eventName);
+    }
+
+    @Test
+    public void testHandleRoleCreatedEvent() throws Exception {
+
+        Event event = createEventWithProperties(IdentityEventConstants.Event.POST_ADD_ROLE_V2_EVENT);
+
+        org.wso2.carbon.identity.webhook.metadata.api.model.Event channelEvent =
+                new org.wso2.carbon.identity.webhook.metadata.api.model.Event(
+                        "roleCreated", "Role created event", ROLE_CREATED_EVENT_URI);
+        Channel channel = new Channel("Role Management", "Role Management Channel", ROLE_CHANNEL_URI,
+                Collections.singletonList(channelEvent));
+        EventProfile eventProfile = new EventProfile("WSO2", "uri", Collections.singletonList(channel));
+
+        when(mockedWebhookMetadataService.getSupportedEventProfiles())
+                .thenReturn(Collections.singletonList(eventProfile));
+
+        try (MockedStatic<PayloadBuilderFactory> mocked = mockStatic(PayloadBuilderFactory.class)) {
+            mocked.when(() -> PayloadBuilderFactory.getRoleManagementEventPayloadBuilder(
+                            org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema.WSO2))
+                    .thenReturn(mockedRoleManagementEventPayloadBuilder);
+
+            when(mockedRoleManagementEventPayloadBuilder.buildRoleCreatedEvent(any(EventData.class)))
+                    .thenReturn(mockedEventPayload);
+
+            try (MockedStatic<EventHookHandlerUtils> utilsMocked = mockStatic(EventHookHandlerUtils.class)) {
+                EventData eventData = mock(EventData.class);
+                EventMetadata eventMetadata = mock(EventMetadata.class);
+                SecurityEventTokenPayload tokenPayload = mock(SecurityEventTokenPayload.class);
+
+                when(eventData.getTenantDomain()).thenReturn(CARBON_SUPER);
+                when(eventMetadata.getChannel()).thenReturn(ROLE_CHANNEL_URI);
+                when(eventMetadata.getEvent()).thenReturn(ROLE_CREATED_EVENT_URI);
+                when(eventMetadata.getEventProfile()).thenReturn("WSO2");
+
+                utilsMocked.when(() -> EventHookHandlerUtils.buildEventDataProvider(any(Event.class)))
+                        .thenReturn(eventData);
+                utilsMocked.when(() -> EventHookHandlerUtils.getEventProfileManagerByProfile(anyString(), anyString()))
+                        .thenReturn(eventMetadata);
+                utilsMocked.when(() -> EventHookHandlerUtils.buildSecurityEventToken(any(), anyString()))
+                        .thenReturn(tokenPayload);
+
+                when(mockedEventPublisherService.canHandleEvent(any(EventContext.class))).thenReturn(true);
+
+                roleManagementEventHookHandler.handleEvent(event);
+
+                verify(mockedEventPublisherService, times(1))
+                        .publish(eq(tokenPayload), argThat(ctx ->
+                                ctx.getTenantDomain().equals(CARBON_SUPER) &&
+                                        ctx.getEventUri().equals(ROLE_CHANNEL_URI) &&
+                                        ctx.getEventProfileName().equals("WSO2")
+                        ));
+            }
+        }
+    }
+
+    @Test
+    public void testCanHandleReturnsFalseForSubOrgContext() throws Exception {
+
+        Event event = new Event(IdentityEventConstants.Event.POST_ADD_ROLE_V2_EVENT);
+        IdentityEventMessageContext messageContext = new IdentityEventMessageContext(event);
+
+        try (MockedStatic<IdentityContext> identityContextMock = mockStatic(IdentityContext.class);
+             MockedStatic<OrganizationManagementUtil> orgUtilMock = mockStatic(OrganizationManagementUtil.class)) {
+            IdentityContext subOrgCtx = mock(IdentityContext.class);
+            when(subOrgCtx.getTenantDomain()).thenReturn("sub-org-tenant");
+            identityContextMock.when(IdentityContext::getThreadLocalIdentityContext).thenReturn(subOrgCtx);
+            orgUtilMock.when(() -> OrganizationManagementUtil.isOrganization("sub-org-tenant")).thenReturn(true);
+
+            assertFalse(roleManagementEventHookHandler.canHandle(messageContext),
+                    "canHandle should return false when execution context is a sub-organization.");
+        }
+
+        try (MockedStatic<IdentityContext> identityContextMock = mockStatic(IdentityContext.class);
+             MockedStatic<OrganizationManagementUtil> orgUtilMock = mockStatic(OrganizationManagementUtil.class)) {
+            IdentityContext rootOrgCtx = mock(IdentityContext.class);
+            when(rootOrgCtx.getTenantDomain()).thenReturn(CARBON_SUPER);
+            identityContextMock.when(IdentityContext::getThreadLocalIdentityContext).thenReturn(rootOrgCtx);
+            orgUtilMock.when(() -> OrganizationManagementUtil.isOrganization(CARBON_SUPER)).thenReturn(false);
+
+            assertTrue(roleManagementEventHookHandler.canHandle(messageContext),
+                    "canHandle should return true for a supported event in root-org context.");
+        }
+
+        // handleEvent path never ran, so no publish interaction expected.
+        verify(mockedEventPublisherService, Mockito.never()).publish(any(), any());
+    }
+
+    @Test
+    public void testCanHandleReturnsFalseWhenNoIdentityContext() {
+
+        Event event = new Event(IdentityEventConstants.Event.POST_ADD_ROLE_V2_EVENT);
+        IdentityEventMessageContext messageContext = new IdentityEventMessageContext(event);
+
+        try (MockedStatic<IdentityContext> identityContextMock = mockStatic(IdentityContext.class);
+             MockedStatic<OrganizationManagementUtil> orgUtilMock = mockStatic(OrganizationManagementUtil.class)) {
+            IdentityContext emptyCtx = mock(IdentityContext.class);
+            when(emptyCtx.getTenantDomain()).thenReturn("sub-org-tenant");
+            identityContextMock.when(IdentityContext::getThreadLocalIdentityContext).thenReturn(emptyCtx);
+            orgUtilMock.when(() -> OrganizationManagementUtil.isOrganization("sub-org-tenant")).thenReturn(true);
+
+            assertFalse(roleManagementEventHookHandler.canHandle(messageContext),
+                    "canHandle should return false when IdentityContext has no RootOrganization " +
+                            "(async worker thread with no context propagation).");
+        }
+    }
+
+    @Test
+    public void testHandleEventWithNoProfiles() throws Exception {
+
+        Event event = createEventWithProperties(IdentityEventConstants.Event.POST_ADD_ROLE_V2_EVENT);
+        when(mockedWebhookMetadataService.getSupportedEventProfiles()).thenReturn(Collections.emptyList());
+        roleManagementEventHookHandler.handleEvent(event);
+        verify(mockedEventPublisherService, times(0)).publish(any(), any());
+    }
+
+    private Event createEventWithProperties(String eventName) {
+
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, CARBON_SUPER);
+        properties.put(IdentityEventConstants.EventProperty.ROLE_ID, "test-role-id");
+        return new Event(eventName, properties);
+    }
+
+    private void setupDataHolderMocks() {
+
+        EventHookHandlerDataHolder.getInstance().setEventPublisherService(mockedEventPublisherService);
+        EventHookHandlerDataHolder.getInstance().setWebhookMetadataService(mockedWebhookMetadataService);
+        EventHookHandlerDataHolder.getInstance().setTopicManagementService(mockedTopicManagementService);
+    }
+
+    private void setupPayloadBuilderMocks() throws IdentityEventException {
+
+        when(mockedRoleManagementEventPayloadBuilder.getEventSchemaType()).thenReturn(
+                org.wso2.identity.webhook.common.event.handler.api.constants.Constants.EventSchema.WSO2);
+        when(mockedRoleManagementEventPayloadBuilder.buildRoleCreatedEvent(any(EventData.class)))
+                .thenReturn(mockedEventPayload);
+        EventHookHandlerDataHolder.getInstance().addRoleManagementEventPayloadBuilder(
+                mockedRoleManagementEventPayloadBuilder);
+    }
+}

--- a/components/org.wso2.identity.webhook.common.event.handler/src/test/resources/testng.xml
+++ b/components/org.wso2.identity.webhook.common.event.handler/src/test/resources/testng.xml
@@ -30,6 +30,7 @@
             <class name="org.wso2.identity.webhook.common.event.handler.internal.util.PayloadBuilderFactoryTest"/>
             <class name="org.wso2.identity.webhook.common.event.handler.internal.component.EventHookHandlerDataHolderTest"/>
             <class name="org.wso2.identity.webhook.common.event.handler.internal.handler.TokenEventHookHandlerTest"/>
+            <class name="org.wso2.identity.webhook.common.event.handler.internal.handler.RoleManagementEventHookHandlerTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.identity.webhook.wso2.event.handler/pom.xml
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/pom.xml
@@ -94,6 +94,14 @@
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.role.v2.mgt.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.idp.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
@@ -186,11 +194,18 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.role.mgt.core;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.role.v2.mgt.core;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.role.v2.mgt.core.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.role.v2.mgt.core.exception;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.tenant; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.core.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
@@ -206,6 +221,8 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.slf4j; version="${org.slf4j.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.mgt.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.idp.mgt;
                             version="${carbon.identity.framework.imp.pkg.version.range}"
                         </Import-Package>
                     </instructions>

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
@@ -492,13 +492,23 @@ public class WSO2RoleManagementEventPayloadBuilder implements RoleManagementEven
 
         List<UserEntry> entries = new ArrayList<>();
         for (String userId : userIds) {
-            String userStoreDomain = resolveUserStoreDomain(userId, userManager);
             Map<String, String> claimValues = resolveUserClaims(userId, userManager,
                     new String[]{USERNAME_CLAIM_URI, AGENT_NAME_CLAIM_URI});
             List<UserClaim> claims = new ArrayList<>();
             String username = claimValues.get(USERNAME_CLAIM_URI);
+            String userStoreDomain = null;
             if (StringUtils.isNotBlank(username)) {
+                // When the username already carries the user-store domain prefix
+                // (e.g. PRIMARY/alice), crop it off and use it as the domain rather
+                // than resolving the domain separately.
+                if (StringUtils.contains(username, UserCoreConstants.DOMAIN_SEPARATOR)) {
+                    userStoreDomain = UserCoreUtil.extractDomainFromName(username);
+                    username = UserCoreUtil.removeDomainFromName(username);
+                }
                 claims.add(new UserClaim.Builder().uri(USERNAME_CLAIM_URI).value(username).build());
+            }
+            if (userStoreDomain == null) {
+                userStoreDomain = resolveUserStoreDomain(userId, userManager);
             }
             String agentName = claimValues.get(AGENT_NAME_CLAIM_URI);
             if (StringUtils.isNotBlank(agentName)) {
@@ -550,7 +560,10 @@ public class WSO2RoleManagementEventPayloadBuilder implements RoleManagementEven
     /**
      * Resolve groups for the given group IDs and return enriched entries. Each entry
      * carries the plain group name and its owning user-store separately (never prefixed).
-     * On lookup failure both fields are null.
+     * When the resolved group name already has the user-store domain appended
+     * (e.g. {@code PRIMARY/dev-team}), the domain is cropped from the name and used
+     * directly instead of reading it off the {@link Group}. On lookup failure both
+     * fields are null.
      */
     private List<GroupEntry> toEnrichedGroupEntries(List<String> groupIds, AbstractUserStoreManager userManager) {
 
@@ -561,10 +574,17 @@ public class WSO2RoleManagementEventPayloadBuilder implements RoleManagementEven
                 entries.add(new GroupEntry(groupId, null, null));
                 continue;
             }
-            String domain = StringUtils.isNotBlank(group.getUserStoreDomain())
-                    ? group.getUserStoreDomain()
-                    : UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
-            entries.add(new GroupEntry(groupId, group.getGroupName(), domain));
+            String groupName = group.getGroupName();
+            String domain;
+            if (StringUtils.contains(groupName, UserCoreConstants.DOMAIN_SEPARATOR)) {
+                domain = UserCoreUtil.extractDomainFromName(groupName);
+                groupName = UserCoreUtil.removeDomainFromName(groupName);
+            } else {
+                domain = StringUtils.isNotBlank(group.getUserStoreDomain())
+                        ? group.getUserStoreDomain()
+                        : UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+            }
+            entries.add(new GroupEntry(groupId, groupName, domain));
         }
         return entries;
     }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
@@ -72,7 +72,6 @@ import java.util.function.IntConsumer;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.RoleManagement.ROLE_LIST_MAX_SIZE;
 import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.AGENT_NAME_CLAIM_URI;
 import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.SCIM2_ROLES_ENDPOINT;
-import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.SCIM2_USERS_ENDPOINT;
 import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.USERNAME_CLAIM_URI;
 
 /**
@@ -482,15 +481,13 @@ public class WSO2RoleManagementEventPayloadBuilder implements RoleManagementEven
 
     /**
      * Build user entries carrying id + user-store domain + selected claims (username,
-     * agent name) + SCIM ref. The agent-name claim is emitted only when non-blank;
-     * agents are identified uniformly through this claim rather than a separate representation.
+     * agent name). The agent-name claim is emitted only when non-blank; agents are
+     * identified uniformly through this claim rather than a separate representation.
      */
     private List<UserEntry> toEnrichedUserEntries(List<String> userIds, AbstractUserStoreManager userManager) {
 
         List<UserEntry> entries = new ArrayList<>();
-        String userRefBase = WSO2PayloadUtils.constructFullURLWithEndpoint(SCIM2_USERS_ENDPOINT);
         for (String userId : userIds) {
-            String ref = userRefBase != null ? userRefBase + "/" + userId : null;
             String userStoreDomain = resolveUserStoreDomain(userId, userManager);
             Map<String, String> claimValues = resolveUserClaims(userId, userManager,
                     new String[]{USERNAME_CLAIM_URI, AGENT_NAME_CLAIM_URI});
@@ -503,7 +500,7 @@ public class WSO2RoleManagementEventPayloadBuilder implements RoleManagementEven
             if (StringUtils.isNotBlank(agentName)) {
                 claims.add(new UserClaim.Builder().uri(AGENT_NAME_CLAIM_URI).value(agentName).build());
             }
-            entries.add(new UserEntry(userId, userStoreDomain, claims.isEmpty() ? null : claims, ref));
+            entries.add(new UserEntry(userId, userStoreDomain, claims.isEmpty() ? null : claims));
         }
         return entries;
     }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
@@ -150,14 +150,16 @@ public class WSO2RoleManagementEventPayloadBuilder implements RoleManagementEven
         Map<String, Object> props = eventData.getEventParams();
         String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
         String roleName = (String) props.get(IdentityEventConstants.EventProperty.ROLE_NAME);
+        String audience = (String) props.get(IdentityEventConstants.EventProperty.AUDIENCE);
+        String audienceId = (String) props.get(IdentityEventConstants.EventProperty.AUDIENCE_ID);
+        String audienceName = (String) props.get(IdentityEventConstants.EventProperty.AUDIENCE_NAME);
 
         EnvelopeContext ctx = new EnvelopeContext();
 
         RoleRef role = new RoleRef();
         role.setId(roleId);
-        if (StringUtils.isNotBlank(roleName)) {
-            role.setName(roleName);
-        }
+        role.setName(roleName);
+        role.setAudience(buildRoleAudience(audience, audienceId, audienceName));
 
         return new WSO2RoleDeletedEventPayload.Builder()
                 .tenant(ctx.tenant)

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
@@ -149,13 +149,15 @@ public class WSO2RoleManagementEventPayloadBuilder implements RoleManagementEven
 
         Map<String, Object> props = eventData.getEventParams();
         String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
+        String roleName = (String) props.get(IdentityEventConstants.EventProperty.ROLE_NAME);
 
         EnvelopeContext ctx = new EnvelopeContext();
 
-        // roleDeleted: no enrichment — role is already gone. Only id in payload.
-        // ref is intentionally omitted since the SCIM resource no longer exists.
         RoleRef role = new RoleRef();
         role.setId(roleId);
+        if (StringUtils.isNotBlank(roleName)) {
+            role.setName(roleName);
+        }
 
         return new WSO2RoleDeletedEventPayload.Builder()
                 .tenant(ctx.tenant)

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilder.java
@@ -1,0 +1,655 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.api.builder;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.IdpGroup;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.Permission;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
+import org.wso2.carbon.idp.mgt.IdpManager;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserCoreConstants;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.common.Group;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.identity.webhook.common.event.handler.api.builder.RoleManagementEventPayloadBuilder;
+import org.wso2.identity.webhook.common.event.handler.api.constants.Constants;
+import org.wso2.identity.webhook.common.event.handler.api.model.EventData;
+import org.wso2.identity.webhook.wso2.event.handler.internal.component.WSO2EventHookHandlerDataHolder;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleCreatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleDeletedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleGroupsUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleIdpGroupsUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RolePermissionsUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleMetaUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.GroupEntry;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.UserEntry;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleUsersUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.Organization;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleAudience;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.Tenant;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.UserClaim;
+import org.wso2.identity.webhook.wso2.event.handler.internal.util.WSO2PayloadUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntConsumer;
+
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.RoleManagement.ROLE_LIST_MAX_SIZE;
+import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.AGENT_NAME_CLAIM_URI;
+import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.SCIM2_ROLES_ENDPOINT;
+import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.SCIM2_USERS_ENDPOINT;
+import static org.wso2.identity.webhook.wso2.event.handler.internal.constant.Constants.USERNAME_CLAIM_URI;
+
+/**
+ * WSO2 Role Management Event Payload Builder.
+ * Builds webhook event payloads for V2 role lifecycle events.
+ */
+public class WSO2RoleManagementEventPayloadBuilder implements RoleManagementEventPayloadBuilder {
+
+    private static final Log LOG = LogFactory.getLog(WSO2RoleManagementEventPayloadBuilder.class);
+
+    @Override
+    public EventPayload buildRoleCreatedEvent(EventData eventData) throws IdentityEventException {
+
+        Map<String, Object> props = eventData.getEventParams();
+        String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
+        String audience = (String) props.get(IdentityEventConstants.EventProperty.AUDIENCE);
+        String audienceId = (String) props.get(IdentityEventConstants.EventProperty.AUDIENCE_ID);
+        String tenantDomain = eventData.getTenantDomain();
+
+        EnvelopeContext ctx = new EnvelopeContext();
+
+        WSO2RoleCreatedEventPayload.RoleWithMembership role =
+                enrichRole(new WSO2RoleCreatedEventPayload.RoleWithMembership(), roleId, tenantDomain);
+        // Fallback to props-audience when RoleBasicInfo lookup did not populate it.
+        if (role.getAudience() == null && StringUtils.isNotBlank(audience)) {
+            role.setAudience(buildRoleAudience(audience, audienceId, null));
+        }
+
+        List<String> userIds = toStringList(props.get(IdentityEventConstants.EventProperty.USER_LIST));
+        List<String> groupIds = toStringList(props.get(IdentityEventConstants.EventProperty.GROUP_LIST));
+        List<String> permissionNames = toPermissionNames(props.get(IdentityEventConstants.EventProperty.PERMISSIONS));
+
+        AbstractUserStoreManager userManager = getAbstractUserStoreManager(tenantDomain);
+        role.setUsers(userIds.isEmpty() ? null : toEnrichedUserEntries(userIds, userManager));
+        role.setGroups(groupIds.isEmpty() ? null : toEnrichedGroupEntries(groupIds, userManager));
+        role.setPermissions(permissionNames.isEmpty() ? null : permissionNames);
+
+        return new WSO2RoleCreatedEventPayload.Builder()
+                .tenant(ctx.tenant)
+                .organization(ctx.organization)
+                .initiatorType(ctx.initiatorType)
+                .initiatorIpAddress(ctx.initiatorIpAddress)
+                .action(ctx.action)
+                .role(role)
+                .build();
+    }
+
+    @Override
+    public EventPayload buildRoleMetaUpdatedEvent(EventData eventData) throws IdentityEventException {
+
+        Map<String, Object> props = eventData.getEventParams();
+        String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
+        String newRoleName = (String) props.get(IdentityEventConstants.EventProperty.NEW_ROLE_NAME);
+        String tenantDomain = eventData.getTenantDomain();
+
+        EnvelopeContext ctx = new EnvelopeContext();
+
+        RoleRef role = enrichRole(new RoleRef(), roleId, tenantDomain);
+        if (StringUtils.isNotBlank(newRoleName)) {
+            role.setName(newRoleName);
+        }
+
+        return new WSO2RoleMetaUpdatedEventPayload.Builder()
+                .tenant(ctx.tenant)
+                .organization(ctx.organization)
+                .initiatorType(ctx.initiatorType)
+                .initiatorIpAddress(ctx.initiatorIpAddress)
+                .action(ctx.action)
+                .role(role)
+                .build();
+    }
+
+    @Override
+    public EventPayload buildRoleDeletedEvent(EventData eventData) throws IdentityEventException {
+
+        Map<String, Object> props = eventData.getEventParams();
+        String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
+
+        EnvelopeContext ctx = new EnvelopeContext();
+
+        // roleDeleted: no enrichment — role is already gone. Only id in payload.
+        // ref is intentionally omitted since the SCIM resource no longer exists.
+        RoleRef role = new RoleRef();
+        role.setId(roleId);
+
+        return new WSO2RoleDeletedEventPayload.Builder()
+                .tenant(ctx.tenant)
+                .organization(ctx.organization)
+                .initiatorType(ctx.initiatorType)
+                .initiatorIpAddress(ctx.initiatorIpAddress)
+                .action(ctx.action)
+                .role(role)
+                .build();
+    }
+
+    @Override
+    public EventPayload buildRoleUsersUpdatedEvent(EventData eventData) throws IdentityEventException {
+
+        Map<String, Object> props = eventData.getEventParams();
+        String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
+        String tenantDomain = eventData.getTenantDomain();
+
+        EnvelopeContext ctx = new EnvelopeContext();
+
+        WSO2RoleUsersUpdatedEventPayload.RoleWithUsers role =
+                enrichRole(new WSO2RoleUsersUpdatedEventPayload.RoleWithUsers(), roleId, tenantDomain);
+
+        List<String> addedUserIds =
+                toStringList(props.get(IdentityEventConstants.EventProperty.NEW_USER_ID_LIST));
+        List<String> removedUserIds =
+                toStringList(props.get(IdentityEventConstants.EventProperty.DELETE_USER_ID_LIST));
+
+        String roleUsersRef = buildRoleRef(roleId) + "/users";
+        final AbstractUserStoreManager userManager = getAbstractUserStoreManager(tenantDomain);
+
+        applyTruncatedList(addedUserIds, ids -> toEnrichedUserEntries(ids, userManager),
+                role::setAddedUsers, role::setAddedUsersTruncated,
+                role::setAddedUsersTotalCount, role::setAddedUsersRef, roleUsersRef);
+        applyTruncatedList(removedUserIds, ids -> toEnrichedUserEntries(ids, userManager),
+                role::setRemovedUsers, role::setRemovedUsersTruncated,
+                role::setRemovedUsersTotalCount, role::setRemovedUsersRef, roleUsersRef);
+
+        return new WSO2RoleUsersUpdatedEventPayload.Builder()
+                .tenant(ctx.tenant)
+                .organization(ctx.organization)
+                .initiatorType(ctx.initiatorType)
+                .initiatorIpAddress(ctx.initiatorIpAddress)
+                .action(ctx.action)
+                .role(role)
+                .build();
+    }
+
+    @Override
+    public EventPayload buildRoleGroupsUpdatedEvent(EventData eventData) throws IdentityEventException {
+
+        Map<String, Object> props = eventData.getEventParams();
+        String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
+        String tenantDomain = eventData.getTenantDomain();
+
+        EnvelopeContext ctx = new EnvelopeContext();
+
+        WSO2RoleGroupsUpdatedEventPayload.RoleWithGroups role =
+                enrichRole(new WSO2RoleGroupsUpdatedEventPayload.RoleWithGroups(), roleId, tenantDomain);
+
+        List<String> addedGroupIds =
+                toStringList(props.get(IdentityEventConstants.EventProperty.NEW_GROUP_ID_LIST));
+        List<String> removedGroupIds =
+                toStringList(props.get(IdentityEventConstants.EventProperty.DELETE_GROUP_ID_LIST));
+
+        String roleRef = buildRoleRef(roleId);
+        final AbstractUserStoreManager userManager = getAbstractUserStoreManager(tenantDomain);
+
+        applyTruncatedList(addedGroupIds, ids -> toEnrichedGroupEntries(ids, userManager),
+                role::setAddedGroups, role::setAddedGroupsTruncated,
+                role::setAddedGroupsTotalCount, role::setAddedGroupsRef, roleRef);
+        applyTruncatedList(removedGroupIds, ids -> toEnrichedGroupEntries(ids, userManager),
+                role::setRemovedGroups, role::setRemovedGroupsTruncated,
+                role::setRemovedGroupsTotalCount, role::setRemovedGroupsRef, roleRef);
+
+        return new WSO2RoleGroupsUpdatedEventPayload.Builder()
+                .tenant(ctx.tenant)
+                .organization(ctx.organization)
+                .initiatorType(ctx.initiatorType)
+                .initiatorIpAddress(ctx.initiatorIpAddress)
+                .action(ctx.action)
+                .role(role)
+                .build();
+    }
+
+    @Override
+    public EventPayload buildRoleIdpGroupsUpdatedEvent(EventData eventData) throws IdentityEventException {
+
+        Map<String, Object> props = eventData.getEventParams();
+        String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
+        String tenantDomain = eventData.getTenantDomain();
+
+        EnvelopeContext ctx = new EnvelopeContext();
+
+        WSO2RoleIdpGroupsUpdatedEventPayload.RoleWithIdpGroups role =
+                enrichRole(new WSO2RoleIdpGroupsUpdatedEventPayload.RoleWithIdpGroups(), roleId, tenantDomain);
+
+        List<IdpGroup> addedIdpGroups = toIdpGroupList(props.get(
+                IdentityEventConstants.EventProperty.NEW_GROUP_ID_LIST));
+        List<IdpGroup> removedIdpGroups = toIdpGroupList(props.get(
+                IdentityEventConstants.EventProperty.DELETE_GROUP_ID_LIST));
+
+        String roleRef = buildRoleRef(roleId);
+
+        applyTruncatedList(addedIdpGroups, groups -> toEnrichedIdpGroupEntries(groups, tenantDomain),
+                role::setAddedIdpGroups, role::setAddedIdpGroupsTruncated,
+                role::setAddedIdpGroupsTotalCount, role::setAddedIdpGroupsRef, roleRef);
+        applyTruncatedList(removedIdpGroups, groups -> toEnrichedIdpGroupEntries(groups, tenantDomain),
+                role::setRemovedIdpGroups, role::setRemovedIdpGroupsTruncated,
+                role::setRemovedIdpGroupsTotalCount, role::setRemovedIdpGroupsRef, roleRef);
+
+        return new WSO2RoleIdpGroupsUpdatedEventPayload.Builder()
+                .tenant(ctx.tenant)
+                .organization(ctx.organization)
+                .initiatorType(ctx.initiatorType)
+                .initiatorIpAddress(ctx.initiatorIpAddress)
+                .action(ctx.action)
+                .role(role)
+                .build();
+    }
+
+    @Override
+    public EventPayload buildRolePermissionsUpdatedEvent(EventData eventData) throws IdentityEventException {
+
+        Map<String, Object> props = eventData.getEventParams();
+        String roleId = (String) props.get(IdentityEventConstants.EventProperty.ROLE_ID);
+        String tenantDomain = eventData.getTenantDomain();
+
+        EnvelopeContext ctx = new EnvelopeContext();
+
+        WSO2RolePermissionsUpdatedEventPayload.RoleWithPermissions role =
+                enrichRole(new WSO2RolePermissionsUpdatedEventPayload.RoleWithPermissions(), roleId, tenantDomain);
+
+        List<String> addedPermissions =
+                toPermissionNames(props.get(IdentityEventConstants.EventProperty.ADDED_PERMISSIONS));
+        List<String> removedPermissions =
+                toPermissionNames(props.get(IdentityEventConstants.EventProperty.DELETED_PERMISSIONS));
+
+        role.setAddedPermissions(addedPermissions.isEmpty() ? null : addedPermissions);
+        role.setRemovedPermissions(removedPermissions.isEmpty() ? null : removedPermissions);
+
+        return new WSO2RolePermissionsUpdatedEventPayload.Builder()
+                .tenant(ctx.tenant)
+                .organization(ctx.organization)
+                .initiatorType(ctx.initiatorType)
+                .initiatorIpAddress(ctx.initiatorIpAddress)
+                .action(ctx.action)
+                .role(role)
+                .build();
+    }
+
+    @Override
+    public Constants.EventSchema getEventSchemaType() {
+
+        return Constants.EventSchema.WSO2;
+    }
+
+    // ---- private helpers ----
+
+    /**
+     * Common envelope fields resolved once per event.
+     */
+    private static class EnvelopeContext {
+
+        final Tenant tenant;
+        final Organization organization;
+        final String initiatorType;
+        final String initiatorIpAddress;
+        final String action;
+
+        EnvelopeContext() {
+
+            this.tenant = WSO2PayloadUtils.buildTenant();
+            this.organization = WSO2PayloadUtils.buildOrganizationFromIdentityContext(
+                    IdentityContext.getThreadLocalIdentityContext());
+            Flow flow = IdentityContext.getThreadLocalIdentityContext().getCurrentFlow();
+            this.initiatorType = WSO2PayloadUtils.getFlowInitiatorType(flow);
+            this.initiatorIpAddress = WSO2PayloadUtils.resolveInitiatorIpAddress();
+            this.action = WSO2PayloadUtils.getFlowAction(flow);
+        }
+    }
+
+    /**
+     * Populate id / ref / name / audience on the given role block by looking up RoleBasicInfo.
+     * Returns the same instance so callers can inline it.
+     */
+    private <R extends RoleRef> R enrichRole(R role, String roleId, String tenantDomain) {
+
+        role.setId(roleId);
+        role.setRef(buildRoleRef(roleId));
+        RoleBasicInfo basicInfo = getRoleBasicInfo(roleId, tenantDomain);
+        if (basicInfo != null) {
+            role.setName(basicInfo.getName());
+            role.setAudience(buildRoleAudience(basicInfo.getAudience(),
+                    basicInfo.getAudienceId(), basicInfo.getAudienceName()));
+        }
+        return role;
+    }
+
+    /**
+     * Apply the "cap + mark truncated" pattern to an added/removed source list.
+     * If the source is empty or null nothing is set; otherwise the mapped entries
+     * are stored, and if the source exceeds {@link Constants.RoleManagement#ROLE_LIST_MAX_SIZE}
+     * the truncated / totalCount / ref siblings are populated.
+     */
+    private static <S, T> void applyTruncatedList(List<S> source, Function<List<S>, List<T>> mapper,
+                                                  Consumer<List<T>> setValues,
+                                                  Consumer<Boolean> setTruncated,
+                                                  IntConsumer setTotalCount,
+                                                  Consumer<String> setRef, String ref) {
+
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+        if (source.size() > ROLE_LIST_MAX_SIZE) {
+            setValues.accept(mapper.apply(source.subList(0, ROLE_LIST_MAX_SIZE)));
+            setTruncated.accept(true);
+            setTotalCount.accept(source.size());
+            setRef.accept(ref);
+        } else {
+            setValues.accept(mapper.apply(source));
+        }
+    }
+
+    /**
+     * Build the SCIM2 roles ref URL for the given role ID in the current tenant context.
+     */
+    private String buildRoleRef(String roleId) {
+
+        String baseUrl = WSO2PayloadUtils.constructFullURLWithEndpoint(SCIM2_ROLES_ENDPOINT);
+        return (baseUrl != null) ? baseUrl + "/" + roleId : null;
+    }
+
+    /**
+     * Fetch RoleBasicInfo from the RoleManagementService (cache-backed).
+     * Returns null on any error so the caller can proceed without enrichment.
+     */
+    private RoleBasicInfo getRoleBasicInfo(String roleId, String tenantDomain) {
+
+        if (StringUtils.isBlank(roleId) || StringUtils.isBlank(tenantDomain)) {
+            return null;
+        }
+        RoleManagementService roleManagementService =
+                WSO2EventHookHandlerDataHolder.getInstance().getRoleManagementService();
+        if (roleManagementService == null) {
+            LOG.debug("RoleManagementService is not available. Skipping enrichment for role: " + roleId);
+            return null;
+        }
+        try {
+            return roleManagementService.getRoleBasicInfoById(roleId, tenantDomain);
+        } catch (IdentityRoleManagementException e) {
+            LOG.debug("Could not fetch RoleBasicInfo for role: " + roleId + " in tenant: " + tenantDomain, e);
+            return null;
+        }
+    }
+
+    /**
+     * Build a RoleAudience from the audience fields.
+     */
+    private RoleAudience buildRoleAudience(String audience, String audienceId, String audienceName) {
+
+        if (StringUtils.isBlank(audience)) {
+            return null;
+        }
+        return new RoleAudience(audience, audienceId, audienceName);
+    }
+
+    /**
+     * Convert a raw object from EventProperties to a List of Strings.
+     */
+    private List<String> toStringList(Object obj) {
+
+        if (obj instanceof List) {
+            List<?> list = (List<?>) obj;
+            List<String> result = new ArrayList<>();
+            for (Object item : list) {
+                if (item instanceof String) {
+                    result.add((String) item);
+                }
+            }
+            return result;
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Extract permission names (the {@code name} field) from a raw list of Permission objects.
+     */
+    private List<String> toPermissionNames(Object obj) {
+
+        if (!(obj instanceof List)) {
+            return Collections.emptyList();
+        }
+        List<String> result = new ArrayList<>();
+        for (Object item : (List<?>) obj) {
+            if (item instanceof Permission) {
+                String name = ((Permission) item).getName();
+                if (name != null) {
+                    result.add(name);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Convert a raw object from EventProperties to a List of IdpGroup.
+     */
+    private List<IdpGroup> toIdpGroupList(Object obj) {
+
+        if (obj instanceof List) {
+            List<?> list = (List<?>) obj;
+            List<IdpGroup> result = new ArrayList<>();
+            for (Object item : list) {
+                if (item instanceof IdpGroup) {
+                    result.add((IdpGroup) item);
+                }
+            }
+            return result;
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Build user entries carrying id + user-store domain + selected claims (username,
+     * agent name) + SCIM ref. The agent-name claim is emitted only when non-blank;
+     * agents are identified uniformly through this claim rather than a separate representation.
+     */
+    private List<UserEntry> toEnrichedUserEntries(List<String> userIds, AbstractUserStoreManager userManager) {
+
+        List<UserEntry> entries = new ArrayList<>();
+        String userRefBase = WSO2PayloadUtils.constructFullURLWithEndpoint(SCIM2_USERS_ENDPOINT);
+        for (String userId : userIds) {
+            String ref = userRefBase != null ? userRefBase + "/" + userId : null;
+            String userStoreDomain = resolveUserStoreDomain(userId, userManager);
+            Map<String, String> claimValues = resolveUserClaims(userId, userManager,
+                    new String[]{USERNAME_CLAIM_URI, AGENT_NAME_CLAIM_URI});
+            List<UserClaim> claims = new ArrayList<>();
+            String username = claimValues.get(USERNAME_CLAIM_URI);
+            if (StringUtils.isNotBlank(username)) {
+                claims.add(new UserClaim.Builder().uri(USERNAME_CLAIM_URI).value(username).build());
+            }
+            String agentName = claimValues.get(AGENT_NAME_CLAIM_URI);
+            if (StringUtils.isNotBlank(agentName)) {
+                claims.add(new UserClaim.Builder().uri(AGENT_NAME_CLAIM_URI).value(agentName).build());
+            }
+            entries.add(new UserEntry(userId, userStoreDomain, claims.isEmpty() ? null : claims, ref));
+        }
+        return entries;
+    }
+
+    /**
+     * Resolve the user-store domain that owns the given userId. Returns null on failure.
+     */
+    private String resolveUserStoreDomain(String userId, AbstractUserStoreManager userManager) {
+
+        if (userManager == null || StringUtils.isBlank(userId)) {
+            return null;
+        }
+        try {
+            String domainQualified = userManager.getUserNameFromUserID(userId);
+            if (StringUtils.isBlank(domainQualified)) {
+                return null;
+            }
+            return UserCoreUtil.extractDomainFromName(domainQualified);
+        } catch (org.wso2.carbon.user.core.UserStoreException e) {
+            LOG.debug("Could not resolve user-store domain for userId: " + userId, e);
+            return null;
+        }
+    }
+
+    /**
+     * Fetch the requested claim values for a user by ID. Returns an empty map on any error.
+     */
+    private Map<String, String> resolveUserClaims(String userId, AbstractUserStoreManager userManager,
+                                                  String[] claimUris) {
+
+        if (userManager == null || StringUtils.isBlank(userId) || claimUris == null || claimUris.length == 0) {
+            return Collections.emptyMap();
+        }
+        try {
+            Map<String, String> values = userManager.getUserClaimValuesWithID(userId, claimUris, null);
+            return values != null ? values : Collections.emptyMap();
+        } catch (org.wso2.carbon.user.core.UserStoreException e) {
+            LOG.debug("Could not resolve claims for userId: " + userId, e);
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Resolve groups for the given group IDs and return enriched entries. Each entry
+     * carries the plain group name and its owning user-store separately (never prefixed).
+     * On lookup failure both fields are null.
+     */
+    private List<GroupEntry> toEnrichedGroupEntries(List<String> groupIds, AbstractUserStoreManager userManager) {
+
+        List<GroupEntry> entries = new ArrayList<>();
+        for (String groupId : groupIds) {
+            Group group = resolveGroupFromGroupId(groupId, userManager);
+            if (group == null) {
+                entries.add(new GroupEntry(groupId, null, null));
+                continue;
+            }
+            String domain = StringUtils.isNotBlank(group.getUserStoreDomain())
+                    ? group.getUserStoreDomain()
+                    : UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+            entries.add(new GroupEntry(groupId, group.getGroupName(), domain));
+        }
+        return entries;
+    }
+
+/**
+     * Build IdpGroupEntry list, resolving missing idpName from IdpManager when absent.
+     */
+    private List<WSO2RoleIdpGroupsUpdatedEventPayload.IdpGroupEntry> toEnrichedIdpGroupEntries(
+            List<IdpGroup> idpGroups, String tenantDomain) {
+
+        List<WSO2RoleIdpGroupsUpdatedEventPayload.IdpGroupEntry> entries = new ArrayList<>();
+        for (IdpGroup idpGroup : idpGroups) {
+            String idpName = idpGroup.getIdpName();
+            if (StringUtils.isBlank(idpName) && StringUtils.isNotBlank(idpGroup.getIdpId())) {
+                idpName = resolveIdpNameFromIdpId(idpGroup.getIdpId(), tenantDomain);
+            }
+            entries.add(new WSO2RoleIdpGroupsUpdatedEventPayload.IdpGroupEntry(
+                    idpGroup.getGroupId(), idpGroup.getGroupName(),
+                    idpGroup.getIdpId(), idpName));
+        }
+        return entries;
+    }
+
+    /**
+     * Obtain an AbstractUserStoreManager for the given tenant. Returns null if unavailable.
+     */
+    private AbstractUserStoreManager getAbstractUserStoreManager(String tenantDomain) {
+
+        RealmService realmService = WSO2EventHookHandlerDataHolder.getInstance().getRealmService();
+        if (realmService == null) {
+            LOG.debug("RealmService unavailable; skipping username/groupName enrichment.");
+            return null;
+        }
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            UserRealm realm = realmService.getTenantUserRealm(tenantId);
+            if (realm == null) {
+                return null;
+            }
+            org.wso2.carbon.user.api.UserStoreManager userManager = realm.getUserStoreManager();
+            if (userManager instanceof AbstractUserStoreManager) {
+                return (AbstractUserStoreManager) userManager;
+            }
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            LOG.debug("Could not obtain UserStoreManager for tenant: " + tenantDomain, e);
+        }
+        return null;
+    }
+
+/**
+     * Fetch the {@link Group} for the given groupId. Returns null on failure or when
+     * the resolved group has no name.
+     */
+    private Group resolveGroupFromGroupId(String groupId, AbstractUserStoreManager userManager) {
+
+        if (userManager == null || StringUtils.isBlank(groupId)) {
+            return null;
+        }
+        try {
+            Group group = userManager.getGroup(groupId, null);
+            if (group == null || StringUtils.isBlank(group.getGroupName())) {
+                return null;
+            }
+            return group;
+        } catch (org.wso2.carbon.user.core.UserStoreException e) {
+            LOG.debug("Could not resolve group for groupId: " + groupId, e);
+            return null;
+        }
+    }
+
+    /**
+     * Resolve IdP display name from idpId (resource ID) via IdpManager. Returns null on failure.
+     */
+    private String resolveIdpNameFromIdpId(String idpId, String tenantDomain) {
+
+        IdpManager idpManager = WSO2EventHookHandlerDataHolder.getInstance().getIdpManager();
+        if (idpManager == null) {
+            LOG.debug("IdpManager unavailable; skipping idpName enrichment for idpId: " + idpId);
+            return null;
+        }
+        try {
+            IdentityProvider idp = idpManager.getIdPByResourceId(idpId, tenantDomain, true);
+            return idp != null ? idp.getIdentityProviderName() : null;
+        } catch (IdentityProviderManagementException e) {
+            LOG.debug("Could not resolve IdP name for idpId: " + idpId + " in tenant: " + tenantDomain, e);
+            return null;
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/component/WSO2EventHookHandlerDataHolder.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/component/WSO2EventHookHandlerDataHolder.java
@@ -22,6 +22,8 @@ import org.wso2.carbon.identity.application.authentication.framework.UserSession
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -34,6 +36,8 @@ public class WSO2EventHookHandlerDataHolder {
     private RealmService realmService;
     private ClaimMetadataManagementService claimMetadataManagementService;
     private ApplicationManagementService applicationManagementService;
+    private RoleManagementService roleManagementService;
+    private IdpManager idpManager;
 
     private UserSessionManagementService userSessionManagementService;
 
@@ -146,5 +150,45 @@ public class WSO2EventHookHandlerDataHolder {
     public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
 
         this.applicationManagementService = applicationManagementService;
+    }
+
+    /**
+     * Get the role management service.
+     *
+     * @return RoleManagementService instance.
+     */
+    public RoleManagementService getRoleManagementService() {
+
+        return roleManagementService;
+    }
+
+    /**
+     * Set the role management service.
+     *
+     * @param roleManagementService RoleManagementService instance.
+     */
+    public void setRoleManagementService(RoleManagementService roleManagementService) {
+
+        this.roleManagementService = roleManagementService;
+    }
+
+    /**
+     * Get the IdP manager.
+     *
+     * @return IdpManager instance.
+     */
+    public IdpManager getIdpManager() {
+
+        return idpManager;
+    }
+
+    /**
+     * Set the IdP manager.
+     *
+     * @param idpManager IdpManager instance.
+     */
+    public void setIdpManager(IdpManager idpManager) {
+
+        this.idpManager = idpManager;
     }
 }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/component/WSO2EventHookHandlerServiceComponent.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/component/WSO2EventHookHandlerServiceComponent.java
@@ -31,7 +31,10 @@ import org.wso2.carbon.identity.application.authentication.framework.UserSession
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.identity.webhook.common.event.handler.api.builder.RoleManagementEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.TokenEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.service.EventProfileManager;
 import org.wso2.identity.webhook.common.event.handler.api.builder.CredentialEventPayloadBuilder;
@@ -39,6 +42,7 @@ import org.wso2.identity.webhook.common.event.handler.api.builder.LoginEventPayl
 import org.wso2.identity.webhook.common.event.handler.api.builder.RegistrationEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.SessionEventPayloadBuilder;
 import org.wso2.identity.webhook.common.event.handler.api.builder.UserOperationEventPayloadBuilder;
+import org.wso2.identity.webhook.wso2.event.handler.api.builder.WSO2RoleManagementEventPayloadBuilder;
 import org.wso2.identity.webhook.wso2.event.handler.api.builder.WSO2TokenEventPayloadBuilder;
 import org.wso2.identity.webhook.wso2.event.handler.internal.service.impl.WSO2EventProfileManager;
 import org.wso2.identity.webhook.wso2.event.handler.api.builder.WSO2CredentialEventPayloadBuilder;
@@ -78,6 +82,8 @@ public class WSO2EventHookHandlerServiceComponent {
                     new WSO2RegistrationEventPayloadBuilder(), null);
             context.getBundleContext().registerService(TokenEventPayloadBuilder.class.getName(),
                     new WSO2TokenEventPayloadBuilder(), null);
+            context.getBundleContext().registerService(RoleManagementEventPayloadBuilder.class.getName(),
+                    new WSO2RoleManagementEventPayloadBuilder(), null);
         } catch (Exception e) {
             log.error("Error while activating event handler.", e);
         }
@@ -206,5 +212,61 @@ public class WSO2EventHookHandlerServiceComponent {
 
         log.debug("Unsetting the Application Management Service");
         WSO2EventHookHandlerDataHolder.getInstance().setApplicationManagementService(null);
+    }
+
+    /**
+     * Set role management service implementation.
+     *
+     * @param roleManagementService RoleManagementService instance
+     */
+    @Reference(
+            name = "role.management.service.component",
+            service = RoleManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRoleManagementService")
+    protected void setRoleManagementService(RoleManagementService roleManagementService) {
+
+        log.debug("Setting the Role Management Service");
+        WSO2EventHookHandlerDataHolder.getInstance().setRoleManagementService(roleManagementService);
+    }
+
+    /**
+     * Unset role management service implementation.
+     *
+     * @param roleManagementService RoleManagementService instance
+     */
+    protected void unsetRoleManagementService(RoleManagementService roleManagementService) {
+
+        log.debug("Unsetting the Role Management Service");
+        WSO2EventHookHandlerDataHolder.getInstance().setRoleManagementService(null);
+    }
+
+    /**
+     * Set IdP manager implementation.
+     *
+     * @param idpManager IdpManager instance
+     */
+    @Reference(
+            name = "idp.manager.component",
+            service = IdpManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdpManager")
+    protected void setIdpManager(IdpManager idpManager) {
+
+        log.debug("Setting the IdP Manager");
+        WSO2EventHookHandlerDataHolder.getInstance().setIdpManager(idpManager);
+    }
+
+    /**
+     * Unset IdP manager implementation.
+     *
+     * @param idpManager IdpManager instance
+     */
+    protected void unsetIdpManager(IdpManager idpManager) {
+
+        log.debug("Unsetting the IdP Manager");
+        WSO2EventHookHandlerDataHolder.getInstance().setIdpManager(null);
     }
 }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/constant/Constants.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/constant/Constants.java
@@ -32,6 +32,7 @@ public class Constants {
     public static final String DATA_MAP = "dataMap";
     public static final String ORGANIZATION_AUTHENTICATOR = "OrganizationAuthenticator";
     public static final String SCIM2_USERS_ENDPOINT = "/scim2/Users";
+    public static final String SCIM2_ROLES_ENDPOINT = "/scim2/v2/Roles";
     public static final String CONSOLE_APP_CONSUMER_KEY = "CONSOLE";
     public static final String CONSOLE_APP_NAME = "Console";
 
@@ -45,5 +46,6 @@ public class Constants {
     public static final String USERNAME_CLAIM_URI = "http://wso2.org/claims/username";
     public static final String EMAIL_CLAIM_URI = "http://wso2.org/claims/emailaddress";
     public static final String WSO2_CLAIM_URI_PREFIX = "http://wso2.org/claims/";
+    public static final String AGENT_NAME_CLAIM_URI = "http://wso2.org/claims/agent/Name";
 
 }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/GroupEntry.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/GroupEntry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+/**
+ * Group entry in a role membership list, carrying id, group name (without user-store prefix),
+ * and the user-store domain the group belongs to.
+ */
+public class GroupEntry {
+
+    private String id;
+    private String groupName;
+    private String userStoreDomain;
+
+    public GroupEntry(String id, String groupName, String userStoreDomain) {
+
+        this.id = id;
+        this.groupName = groupName;
+        this.userStoreDomain = userStoreDomain;
+    }
+
+    public String getId() {
+
+        return id;
+    }
+
+    public String getGroupName() {
+
+        return groupName;
+    }
+
+    public String getUserStoreDomain() {
+
+        return userStoreDomain;
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/UserEntry.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/UserEntry.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.UserClaim;
+
+import java.util.List;
+
+/**
+ * User entry in a role membership list. Carries the user's id, the user-store domain,
+ * a list of claims (e.g. username, agent name), and a SCIM resource ref. Agents —
+ * identified by their user-store — surface additional identifiers as claims rather
+ * than a separate representation.
+ */
+public class UserEntry {
+
+    private String id;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String userStoreDomain;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<UserClaim> claims;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String ref;
+
+    public UserEntry(String id, String userStoreDomain, List<UserClaim> claims, String ref) {
+
+        this.id = id;
+        this.userStoreDomain = userStoreDomain;
+        this.claims = claims;
+        this.ref = ref;
+    }
+
+    public String getId() {
+
+        return id;
+    }
+
+    public String getUserStoreDomain() {
+
+        return userStoreDomain;
+    }
+
+    public List<UserClaim> getClaims() {
+
+        return claims;
+    }
+
+    public String getRef() {
+
+        return ref;
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/UserEntry.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/UserEntry.java
@@ -25,9 +25,9 @@ import java.util.List;
 
 /**
  * User entry in a role membership list. Carries the user's id, the user-store domain,
- * a list of claims (e.g. username, agent name), and a SCIM resource ref. Agents —
- * identified by their user-store — surface additional identifiers as claims rather
- * than a separate representation.
+ * and a list of claims (e.g. username, agent name). Agents — identified by their
+ * user-store — surface additional identifiers as claims rather than a separate
+ * representation.
  */
 public class UserEntry {
 
@@ -36,15 +36,12 @@ public class UserEntry {
     private String userStoreDomain;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<UserClaim> claims;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private String ref;
 
-    public UserEntry(String id, String userStoreDomain, List<UserClaim> claims, String ref) {
+    public UserEntry(String id, String userStoreDomain, List<UserClaim> claims) {
 
         this.id = id;
         this.userStoreDomain = userStoreDomain;
         this.claims = claims;
-        this.ref = ref;
     }
 
     public String getId() {
@@ -60,10 +57,5 @@ public class UserEntry {
     public List<UserClaim> getClaims() {
 
         return claims;
-    }
-
-    public String getRef() {
-
-        return ref;
     }
 }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2AbstractRoleListEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2AbstractRoleListEventPayload.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.Organization;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.Tenant;
+
+/**
+ * Common base for role list-updated events whose payload carries a specific
+ * {@link RoleRef} subtype (users/groups/IdP groups) plus the standard envelope
+ * fields. The self-typed {@link Builder} lets concrete subclasses expose a
+ * fluent API without redeclaring every setter.
+ *
+ * @param <R> concrete role block type (e.g. {@code RoleWithUsers}, extends {@link RoleRef}).
+ */
+public abstract class WSO2AbstractRoleListEventPayload<R extends RoleRef> extends WSO2BaseEventPayload {
+
+    protected R role;
+
+    protected WSO2AbstractRoleListEventPayload(Builder<?, R> builder) {
+
+        this.tenant = builder.tenant;
+        this.organization = builder.organization;
+        this.initiatorType = builder.initiatorType;
+        this.initiatorIpAddress = builder.initiatorIpAddress;
+        this.action = builder.action;
+        this.role = builder.role;
+    }
+
+    public R getRole() {
+
+        return role;
+    }
+
+    /**
+     * Self-typed builder base for role list-updated events.
+     */
+    public abstract static class Builder<B extends Builder<B, R>, R extends RoleRef> {
+
+        protected Tenant tenant;
+        protected Organization organization;
+        protected String initiatorType;
+        protected String initiatorIpAddress;
+        protected String action;
+        protected R role;
+
+        protected abstract B self();
+
+        public B tenant(Tenant tenant) {
+
+            this.tenant = tenant;
+            return self();
+        }
+
+        public B organization(Organization organization) {
+
+            this.organization = organization;
+            return self();
+        }
+
+        public B initiatorType(String initiatorType) {
+
+            this.initiatorType = initiatorType;
+            return self();
+        }
+
+        public B initiatorIpAddress(String initiatorIpAddress) {
+
+            this.initiatorIpAddress = initiatorIpAddress;
+            return self();
+        }
+
+        public B action(String action) {
+
+            this.action = action;
+            return self();
+        }
+
+        public B role(R role) {
+
+            this.role = role;
+            return self();
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleCreatedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleCreatedEventPayload.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+
+import java.util.List;
+
+/**
+ * Payload model for roleCreated events.
+ */
+public class WSO2RoleCreatedEventPayload
+        extends WSO2AbstractRoleListEventPayload<WSO2RoleCreatedEventPayload.RoleWithMembership> {
+
+    private WSO2RoleCreatedEventPayload(Builder builder) {
+
+        super(builder);
+    }
+
+    /**
+     * Builder for WSO2RoleCreatedEventPayload.
+     */
+    public static class Builder
+            extends WSO2AbstractRoleListEventPayload.Builder<Builder, RoleWithMembership> {
+
+        @Override
+        protected Builder self() {
+
+            return this;
+        }
+
+        public WSO2RoleCreatedEventPayload build() {
+
+            return new WSO2RoleCreatedEventPayload(this);
+        }
+    }
+
+    /**
+     * Role block for roleCreated events, carrying initial membership and permissions.
+     * Inherits id / name / audience / ref from {@link RoleRef}.
+     */
+    public static class RoleWithMembership extends RoleRef {
+
+        private List<UserEntry> users;
+        private List<GroupEntry> groups;
+        private List<String> permissions;
+
+        public List<UserEntry> getUsers() {
+
+            return users;
+        }
+
+        public void setUsers(List<UserEntry> users) {
+
+            this.users = users;
+        }
+
+        public List<GroupEntry> getGroups() {
+
+            return groups;
+        }
+
+        public void setGroups(List<GroupEntry> groups) {
+
+            this.groups = groups;
+        }
+
+        public List<String> getPermissions() {
+
+            return permissions;
+        }
+
+        public void setPermissions(List<String> permissions) {
+
+            this.permissions = permissions;
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleDeletedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleDeletedEventPayload.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+
+/**
+ * Payload model for roleDeleted events.
+ * Only role id and ref are present since the role no longer exists when the event fires.
+ */
+public class WSO2RoleDeletedEventPayload extends WSO2AbstractRoleListEventPayload<RoleRef> {
+
+    private WSO2RoleDeletedEventPayload(Builder builder) {
+
+        super(builder);
+    }
+
+    /**
+     * Builder for WSO2RoleDeletedEventPayload.
+     */
+    public static class Builder extends WSO2AbstractRoleListEventPayload.Builder<Builder, RoleRef> {
+
+        @Override
+        protected Builder self() {
+
+            return this;
+        }
+
+        public WSO2RoleDeletedEventPayload build() {
+
+            return new WSO2RoleDeletedEventPayload(this);
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleGroupsUpdatedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleGroupsUpdatedEventPayload.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+
+import java.util.List;
+
+/**
+ * Payload model for roleGroupsUpdated events.
+ * Added/removed group lists and truncation metadata are nested inside the role block.
+ */
+public class WSO2RoleGroupsUpdatedEventPayload
+        extends WSO2AbstractRoleListEventPayload<WSO2RoleGroupsUpdatedEventPayload.RoleWithGroups> {
+
+    private WSO2RoleGroupsUpdatedEventPayload(Builder builder) {
+
+        super(builder);
+    }
+
+    /**
+     * Builder for WSO2RoleGroupsUpdatedEventPayload.
+     */
+    public static class Builder
+            extends WSO2AbstractRoleListEventPayload.Builder<Builder, RoleWithGroups> {
+
+        @Override
+        protected Builder self() {
+
+            return this;
+        }
+
+        public WSO2RoleGroupsUpdatedEventPayload build() {
+
+            return new WSO2RoleGroupsUpdatedEventPayload(this);
+        }
+    }
+
+    /**
+     * Role block for roleGroupsUpdated events, carrying capped added/removed group lists
+     * with optional truncation metadata. Inherits id / name / audience / ref from {@link RoleRef}.
+     */
+    public static class RoleWithGroups extends RoleRef {
+
+        private List<GroupEntry> addedGroups;
+        private List<GroupEntry> removedGroups;
+        private Boolean addedGroupsTruncated;
+        private Integer addedGroupsTotalCount;
+        private String addedGroupsRef;
+        private Boolean removedGroupsTruncated;
+        private Integer removedGroupsTotalCount;
+        private String removedGroupsRef;
+
+        public List<GroupEntry> getAddedGroups() {
+
+            return addedGroups;
+        }
+
+        public void setAddedGroups(List<GroupEntry> addedGroups) {
+
+            this.addedGroups = addedGroups;
+        }
+
+        public List<GroupEntry> getRemovedGroups() {
+
+            return removedGroups;
+        }
+
+        public void setRemovedGroups(List<GroupEntry> removedGroups) {
+
+            this.removedGroups = removedGroups;
+        }
+
+        public Boolean getAddedGroupsTruncated() {
+
+            return addedGroupsTruncated;
+        }
+
+        public void setAddedGroupsTruncated(Boolean addedGroupsTruncated) {
+
+            this.addedGroupsTruncated = addedGroupsTruncated;
+        }
+
+        public Integer getAddedGroupsTotalCount() {
+
+            return addedGroupsTotalCount;
+        }
+
+        public void setAddedGroupsTotalCount(Integer addedGroupsTotalCount) {
+
+            this.addedGroupsTotalCount = addedGroupsTotalCount;
+        }
+
+        public String getAddedGroupsRef() {
+
+            return addedGroupsRef;
+        }
+
+        public void setAddedGroupsRef(String addedGroupsRef) {
+
+            this.addedGroupsRef = addedGroupsRef;
+        }
+
+        public Boolean getRemovedGroupsTruncated() {
+
+            return removedGroupsTruncated;
+        }
+
+        public void setRemovedGroupsTruncated(Boolean removedGroupsTruncated) {
+
+            this.removedGroupsTruncated = removedGroupsTruncated;
+        }
+
+        public Integer getRemovedGroupsTotalCount() {
+
+            return removedGroupsTotalCount;
+        }
+
+        public void setRemovedGroupsTotalCount(Integer removedGroupsTotalCount) {
+
+            this.removedGroupsTotalCount = removedGroupsTotalCount;
+        }
+
+        public String getRemovedGroupsRef() {
+
+            return removedGroupsRef;
+        }
+
+        public void setRemovedGroupsRef(String removedGroupsRef) {
+
+            this.removedGroupsRef = removedGroupsRef;
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleIdpGroupsUpdatedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleIdpGroupsUpdatedEventPayload.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+
+import java.util.List;
+
+/**
+ * Payload model for roleIdpGroupsUpdated events.
+ * Added/removed IdP group lists and truncation metadata are nested inside the role block.
+ */
+public class WSO2RoleIdpGroupsUpdatedEventPayload
+        extends WSO2AbstractRoleListEventPayload<WSO2RoleIdpGroupsUpdatedEventPayload.RoleWithIdpGroups> {
+
+    private WSO2RoleIdpGroupsUpdatedEventPayload(Builder builder) {
+
+        super(builder);
+    }
+
+    /**
+     * Builder for WSO2RoleIdpGroupsUpdatedEventPayload.
+     */
+    public static class Builder
+            extends WSO2AbstractRoleListEventPayload.Builder<Builder, RoleWithIdpGroups> {
+
+        @Override
+        protected Builder self() {
+
+            return this;
+        }
+
+        public WSO2RoleIdpGroupsUpdatedEventPayload build() {
+
+            return new WSO2RoleIdpGroupsUpdatedEventPayload(this);
+        }
+    }
+
+    /**
+     * Role block for roleIdpGroupsUpdated events, carrying capped added/removed IdP group lists
+     * with optional truncation metadata. Inherits id / name / audience / ref from {@link RoleRef}.
+     */
+    public static class RoleWithIdpGroups extends RoleRef {
+
+        private List<IdpGroupEntry> addedIdpGroups;
+        private List<IdpGroupEntry> removedIdpGroups;
+        private Boolean addedIdpGroupsTruncated;
+        private Integer addedIdpGroupsTotalCount;
+        private String addedIdpGroupsRef;
+        private Boolean removedIdpGroupsTruncated;
+        private Integer removedIdpGroupsTotalCount;
+        private String removedIdpGroupsRef;
+
+        public List<IdpGroupEntry> getAddedIdpGroups() {
+
+            return addedIdpGroups;
+        }
+
+        public void setAddedIdpGroups(List<IdpGroupEntry> addedIdpGroups) {
+
+            this.addedIdpGroups = addedIdpGroups;
+        }
+
+        public List<IdpGroupEntry> getRemovedIdpGroups() {
+
+            return removedIdpGroups;
+        }
+
+        public void setRemovedIdpGroups(List<IdpGroupEntry> removedIdpGroups) {
+
+            this.removedIdpGroups = removedIdpGroups;
+        }
+
+        public Boolean getAddedIdpGroupsTruncated() {
+
+            return addedIdpGroupsTruncated;
+        }
+
+        public void setAddedIdpGroupsTruncated(Boolean addedIdpGroupsTruncated) {
+
+            this.addedIdpGroupsTruncated = addedIdpGroupsTruncated;
+        }
+
+        public Integer getAddedIdpGroupsTotalCount() {
+
+            return addedIdpGroupsTotalCount;
+        }
+
+        public void setAddedIdpGroupsTotalCount(Integer addedIdpGroupsTotalCount) {
+
+            this.addedIdpGroupsTotalCount = addedIdpGroupsTotalCount;
+        }
+
+        public String getAddedIdpGroupsRef() {
+
+            return addedIdpGroupsRef;
+        }
+
+        public void setAddedIdpGroupsRef(String addedIdpGroupsRef) {
+
+            this.addedIdpGroupsRef = addedIdpGroupsRef;
+        }
+
+        public Boolean getRemovedIdpGroupsTruncated() {
+
+            return removedIdpGroupsTruncated;
+        }
+
+        public void setRemovedIdpGroupsTruncated(Boolean removedIdpGroupsTruncated) {
+
+            this.removedIdpGroupsTruncated = removedIdpGroupsTruncated;
+        }
+
+        public Integer getRemovedIdpGroupsTotalCount() {
+
+            return removedIdpGroupsTotalCount;
+        }
+
+        public void setRemovedIdpGroupsTotalCount(Integer removedIdpGroupsTotalCount) {
+
+            this.removedIdpGroupsTotalCount = removedIdpGroupsTotalCount;
+        }
+
+        public String getRemovedIdpGroupsRef() {
+
+            return removedIdpGroupsRef;
+        }
+
+        public void setRemovedIdpGroupsRef(String removedIdpGroupsRef) {
+
+            this.removedIdpGroupsRef = removedIdpGroupsRef;
+        }
+    }
+
+    /**
+     * Represents an IdP group entry with groupId, groupName, idpId and idpName.
+     */
+    public static class IdpGroupEntry {
+
+        private String groupId;
+        private String groupName;
+        private String idpId;
+        private String idpName;
+
+        public IdpGroupEntry(String groupId, String groupName, String idpId, String idpName) {
+
+            this.groupId = groupId;
+            this.groupName = groupName;
+            this.idpId = idpId;
+            this.idpName = idpName;
+        }
+
+        public String getGroupId() {
+
+            return groupId;
+        }
+
+        public String getGroupName() {
+
+            return groupName;
+        }
+
+        public String getIdpId() {
+
+            return idpId;
+        }
+
+        public String getIdpName() {
+
+            return idpName;
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleMetaUpdatedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleMetaUpdatedEventPayload.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+
+/**
+ * Payload model for roleMetaUpdated events (role name change and other metadata mutations).
+ */
+public class WSO2RoleMetaUpdatedEventPayload extends WSO2AbstractRoleListEventPayload<RoleRef> {
+
+    private WSO2RoleMetaUpdatedEventPayload(Builder builder) {
+
+        super(builder);
+    }
+
+    /**
+     * Builder for WSO2RoleMetaUpdatedEventPayload.
+     */
+    public static class Builder extends WSO2AbstractRoleListEventPayload.Builder<Builder, RoleRef> {
+
+        @Override
+        protected Builder self() {
+
+            return this;
+        }
+
+        public WSO2RoleMetaUpdatedEventPayload build() {
+
+            return new WSO2RoleMetaUpdatedEventPayload(this);
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RolePermissionsUpdatedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RolePermissionsUpdatedEventPayload.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+
+import java.util.List;
+
+/**
+ * Payload model for rolePermissionsUpdated events.
+ * Added/removed permission lists (as permission name strings) are nested inside the role block.
+ */
+public class WSO2RolePermissionsUpdatedEventPayload
+        extends WSO2AbstractRoleListEventPayload<WSO2RolePermissionsUpdatedEventPayload.RoleWithPermissions> {
+
+    private WSO2RolePermissionsUpdatedEventPayload(Builder builder) {
+
+        super(builder);
+    }
+
+    /**
+     * Builder for WSO2RolePermissionsUpdatedEventPayload.
+     */
+    public static class Builder
+            extends WSO2AbstractRoleListEventPayload.Builder<Builder, RoleWithPermissions> {
+
+        @Override
+        protected Builder self() {
+
+            return this;
+        }
+
+        public WSO2RolePermissionsUpdatedEventPayload build() {
+
+            return new WSO2RolePermissionsUpdatedEventPayload(this);
+        }
+    }
+
+    /**
+     * Role block for rolePermissionsUpdated events, carrying added/removed permission name strings.
+     * Inherits id / name / audience / ref from {@link RoleRef}.
+     */
+    public static class RoleWithPermissions extends RoleRef {
+
+        private List<String> addedPermissions;
+        private List<String> removedPermissions;
+
+        public List<String> getAddedPermissions() {
+
+            return addedPermissions;
+        }
+
+        public void setAddedPermissions(List<String> addedPermissions) {
+
+            this.addedPermissions = addedPermissions;
+        }
+
+        public List<String> getRemovedPermissions() {
+
+            return removedPermissions;
+        }
+
+        public void setRemovedPermissions(List<String> removedPermissions) {
+
+            this.removedPermissions = removedPermissions;
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleUsersUpdatedEventPayload.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/WSO2RoleUsersUpdatedEventPayload.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model;
+
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.common.RoleRef;
+
+import java.util.List;
+
+/**
+ * Payload model for roleUsersUpdated events.
+ * Added/removed user lists and truncation metadata are nested inside the role block.
+ */
+public class WSO2RoleUsersUpdatedEventPayload
+        extends WSO2AbstractRoleListEventPayload<WSO2RoleUsersUpdatedEventPayload.RoleWithUsers> {
+
+    private WSO2RoleUsersUpdatedEventPayload(Builder builder) {
+
+        super(builder);
+    }
+
+    /**
+     * Builder for WSO2RoleUsersUpdatedEventPayload.
+     */
+    public static class Builder
+            extends WSO2AbstractRoleListEventPayload.Builder<Builder, RoleWithUsers> {
+
+        @Override
+        protected Builder self() {
+
+            return this;
+        }
+
+        public WSO2RoleUsersUpdatedEventPayload build() {
+
+            return new WSO2RoleUsersUpdatedEventPayload(this);
+        }
+    }
+
+    /**
+     * Role block for roleUsersUpdated events, carrying capped added/removed user lists
+     * with optional truncation metadata. Inherits id / name / audience / ref from {@link RoleRef}.
+     */
+    public static class RoleWithUsers extends RoleRef {
+
+        private List<UserEntry> addedUsers;
+        private List<UserEntry> removedUsers;
+        private Boolean addedUsersTruncated;
+        private Integer addedUsersTotalCount;
+        private String addedUsersRef;
+        private Boolean removedUsersTruncated;
+        private Integer removedUsersTotalCount;
+        private String removedUsersRef;
+
+        public List<UserEntry> getAddedUsers() {
+
+            return addedUsers;
+        }
+
+        public void setAddedUsers(List<UserEntry> addedUsers) {
+
+            this.addedUsers = addedUsers;
+        }
+
+        public List<UserEntry> getRemovedUsers() {
+
+            return removedUsers;
+        }
+
+        public void setRemovedUsers(List<UserEntry> removedUsers) {
+
+            this.removedUsers = removedUsers;
+        }
+
+        public Boolean getAddedUsersTruncated() {
+
+            return addedUsersTruncated;
+        }
+
+        public void setAddedUsersTruncated(Boolean addedUsersTruncated) {
+
+            this.addedUsersTruncated = addedUsersTruncated;
+        }
+
+        public Integer getAddedUsersTotalCount() {
+
+            return addedUsersTotalCount;
+        }
+
+        public void setAddedUsersTotalCount(Integer addedUsersTotalCount) {
+
+            this.addedUsersTotalCount = addedUsersTotalCount;
+        }
+
+        public String getAddedUsersRef() {
+
+            return addedUsersRef;
+        }
+
+        public void setAddedUsersRef(String addedUsersRef) {
+
+            this.addedUsersRef = addedUsersRef;
+        }
+
+        public Boolean getRemovedUsersTruncated() {
+
+            return removedUsersTruncated;
+        }
+
+        public void setRemovedUsersTruncated(Boolean removedUsersTruncated) {
+
+            this.removedUsersTruncated = removedUsersTruncated;
+        }
+
+        public Integer getRemovedUsersTotalCount() {
+
+            return removedUsersTotalCount;
+        }
+
+        public void setRemovedUsersTotalCount(Integer removedUsersTotalCount) {
+
+            this.removedUsersTotalCount = removedUsersTotalCount;
+        }
+
+        public String getRemovedUsersRef() {
+
+            return removedUsersRef;
+        }
+
+        public void setRemovedUsersRef(String removedUsersRef) {
+
+            this.removedUsersRef = removedUsersRef;
+        }
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/RoleAudience.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/RoleAudience.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model.common;
+
+/**
+ * Represents the audience scoping of a V2 role.
+ * The audience can be an ORGANIZATION or an APPLICATION.
+ */
+public class RoleAudience {
+
+    private String type;
+    private String value;
+    private String display;
+
+    public RoleAudience() {
+
+    }
+
+    public RoleAudience(String type, String value, String display) {
+
+        this.type = type;
+        this.value = value;
+        this.display = display;
+    }
+
+    public String getType() {
+
+        return type;
+    }
+
+    public void setType(String type) {
+
+        this.type = type;
+    }
+
+    public String getValue() {
+
+        return value;
+    }
+
+    public void setValue(String value) {
+
+        this.value = value;
+    }
+
+    public String getDisplay() {
+
+        return display;
+    }
+
+    public void setDisplay(String display) {
+
+        this.display = display;
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/RoleRef.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/RoleRef.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.internal.model.common;
+
+/**
+ * Represents a role with its audience scoping and SCIM ref URL.
+ */
+public class RoleRef {
+
+    private String id;
+    private String name;
+    private RoleAudience audience;
+    private String ref;
+
+    public String getId() {
+
+        return id;
+    }
+
+    public void setId(String id) {
+
+        this.id = id;
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public RoleAudience getAudience() {
+
+        return audience;
+    }
+
+    public void setAudience(RoleAudience audience) {
+
+        this.audience = audience;
+    }
+
+    public String getRef() {
+
+        return ref;
+    }
+
+    public void setRef(String ref) {
+
+        this.ref = ref;
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/UserClaim.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/model/common/UserClaim.java
@@ -18,12 +18,15 @@
 
 package org.wso2.identity.webhook.wso2.event.handler.internal.model.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * User claim class.
  */
 public class UserClaim {
 
     private String uri;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Object value;
 
     public UserClaim(Builder builder) {

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/service/impl/WSO2EventProfileManager.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/service/impl/WSO2EventProfileManager.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Channel.CREDENTIAL_CHANGE_CHANNEL;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Channel.LOGIN_CHANNEL;
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Channel.ROLE_MANAGEMENT_CHANNEL;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Channel.SESSION_CHANNEL;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Channel.TOKEN_CHANNEL;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Channel.USER_OPERATION_CHANNEL;
@@ -42,6 +43,13 @@ import static org.wso2.identity.webhook.common.event.handler.api.constants.Const
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.POST_UPDATE_USER_LIST_OF_ROLE_EVENT;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.POST_USER_CREATED_EVENT;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.POST_USER_PROFILE_UPDATED_EVENT;
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.ROLE_CREATED_EVENT;
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.ROLE_DELETED_EVENT;
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.ROLE_GROUPS_UPDATED_EVENT;
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.ROLE_IDP_GROUPS_UPDATED_EVENT;
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.ROLE_PERMISSIONS_UPDATED_EVENT;
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.ROLE_META_UPDATED_EVENT;
+import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.ROLE_USERS_UPDATED_EVENT;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.SESSION_CREATED_EVENT;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.SESSION_PRESENTED_EVENT;
 import static org.wso2.identity.webhook.common.event.handler.api.constants.Constants.Event.SESSION_REVOKED_EVENT;
@@ -121,6 +129,27 @@ public class WSO2EventProfileManager implements EventProfileManager {
             } else if (IdentityEventConstants.Event.TOKEN_REVOKED.equals(eventName)) {
                 channel = TOKEN_CHANNEL;
                 event = TOKEN_REVOKED_EVENT;
+            } else if (IdentityEventConstants.Event.POST_ADD_ROLE_V2_EVENT.equals(eventName)) {
+                channel = ROLE_MANAGEMENT_CHANNEL;
+                event = ROLE_CREATED_EVENT;
+            } else if (IdentityEventConstants.Event.POST_UPDATE_ROLE_V2_NAME_EVENT.equals(eventName)) {
+                channel = ROLE_MANAGEMENT_CHANNEL;
+                event = ROLE_META_UPDATED_EVENT;
+            } else if (IdentityEventConstants.Event.POST_DELETE_ROLE_V2_EVENT.equals(eventName)) {
+                channel = ROLE_MANAGEMENT_CHANNEL;
+                event = ROLE_DELETED_EVENT;
+            } else if (IdentityEventConstants.Event.POST_UPDATE_USER_LIST_OF_ROLE_V2_EVENT.equals(eventName)) {
+                channel = ROLE_MANAGEMENT_CHANNEL;
+                event = ROLE_USERS_UPDATED_EVENT;
+            } else if (IdentityEventConstants.Event.POST_UPDATE_GROUP_LIST_OF_ROLE_V2_EVENT.equals(eventName)) {
+                channel = ROLE_MANAGEMENT_CHANNEL;
+                event = ROLE_GROUPS_UPDATED_EVENT;
+            } else if (IdentityEventConstants.Event.POST_UPDATE_IDP_GROUP_LIST_OF_ROLE_V2_EVENT.equals(eventName)) {
+                channel = ROLE_MANAGEMENT_CHANNEL;
+                event = ROLE_IDP_GROUPS_UPDATED_EVENT;
+            } else if (IdentityEventConstants.Event.POST_UPDATE_PERMISSIONS_FOR_ROLE_V2_EVENT.equals(eventName)) {
+                channel = ROLE_MANAGEMENT_CHANNEL;
+                event = ROLE_PERMISSIONS_UPDATED_EVENT;
             }
         }
         return EventMetadata.builder()

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/util/WSO2PayloadUtils.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/util/WSO2PayloadUtils.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.core.context.model.RootOrganization;
 import org.wso2.carbon.identity.core.context.util.IdentityContextUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
@@ -573,10 +574,14 @@ public class WSO2PayloadUtils {
      */
     public static Tenant buildTenant() {
 
-        String rootTenantId = String.valueOf(
-                IdentityContext.getThreadLocalIdentityContext().getRootOrganization().getAssociatedTenantId());
-        String rootTenantDomain = String.valueOf(
-                IdentityContext.getThreadLocalIdentityContext().getRootOrganization().getAssociatedTenantDomain());
+        RootOrganization rootOrganization = IdentityContext.getThreadLocalIdentityContext()
+            .getRootOrganization();
+        if (rootOrganization == null) {
+            log.debug("Root organization is not available in the identity context.");
+            return null;
+        }
+        String rootTenantId = String.valueOf(rootOrganization.getAssociatedTenantId());
+        String rootTenantDomain = String.valueOf(rootOrganization.getAssociatedTenantDomain());
 
         return new Tenant(rootTenantId, rootTenantDomain);
     }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/util/WSO2PayloadUtils.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/main/java/org/wso2/identity/webhook/wso2/event/handler/internal/util/WSO2PayloadUtils.java
@@ -282,7 +282,7 @@ public class WSO2PayloadUtils {
 
     public static Optional<UserClaim> generateUserClaim(String claimKey, String claimValue, String tenantDomain) {
 
-        if (StringUtils.isBlank(claimKey) || StringUtils.isBlank(claimValue)) {
+        if (StringUtils.isBlank(claimKey) || claimValue == null) {
             return Optional.empty();
         }
 

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilderTest.java
@@ -240,13 +240,11 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
         UserEntry user1 = created.getRole().getUsers().get(0);
         assertEquals(user1.getId(), USER_ID_1);
         assertEquals(user1.getUserStoreDomain(), USER_STORE_1);
-        assertNotNull(user1.getRef());
         assertUsernameClaim(user1, USERNAME_1);
         assertNoAgentNameClaim(user1);
         UserEntry user2 = created.getRole().getUsers().get(1);
         assertEquals(user2.getId(), USER_ID_2);
         assertEquals(user2.getUserStoreDomain(), USER_STORE_2);
-        assertNotNull(user2.getRef());
         assertUsernameClaim(user2, USERNAME_2);
         assertAgentNameClaim(user2, AGENT_NAME_2);
         assertNotNull(created.getRole().getGroups());
@@ -339,7 +337,6 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
         UserEntry addedUser = userList.getRole().getAddedUsers().get(0);
         assertEquals(addedUser.getId(), USER_ID_1);
         assertEquals(addedUser.getUserStoreDomain(), USER_STORE_1);
-        assertNotNull(addedUser.getRef());
         assertUsernameClaim(addedUser, USERNAME_1);
         assertNoAgentNameClaim(addedUser);
         assertNotNull(userList.getRole().getRemovedUsers());
@@ -347,7 +344,6 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
         UserEntry removedUser = userList.getRole().getRemovedUsers().get(0);
         assertEquals(removedUser.getId(), USER_ID_2);
         assertEquals(removedUser.getUserStoreDomain(), USER_STORE_2);
-        assertNotNull(removedUser.getRef());
         assertUsernameClaim(removedUser, USERNAME_2);
         assertAgentNameClaim(removedUser, AGENT_NAME_2);
     }

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilderTest.java
@@ -301,6 +301,7 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
         EventData eventData = mock(EventData.class);
         Map<String, Object> props = new HashMap<>();
         props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.ROLE_NAME, ROLE_NAME);
         when(eventData.getEventParams()).thenReturn(props);
         when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
 
@@ -312,6 +313,8 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
         WSO2RoleDeletedEventPayload deleted = (WSO2RoleDeletedEventPayload) payload;
         assertNotNull(deleted.getRole());
         assertEquals(deleted.getRole().getId(), ROLE_ID);
+        assertEquals(deleted.getRole().getName(), ROLE_NAME);
+        assertEquals(deleted.getAction(), "USER_GROUP_UPDATE");
     }
 
     @Test

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilderTest.java
@@ -1,0 +1,521 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.webhook.wso2.event.handler.api.builder;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.Flow;
+import org.wso2.carbon.identity.core.context.model.Organization;
+import org.wso2.carbon.identity.core.context.model.RootOrganization;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.publisher.api.model.EventPayload;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.IdpGroup;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.Permission;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
+import org.wso2.carbon.idp.mgt.IdpManager;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.common.Group;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.identity.webhook.common.event.handler.api.constants.Constants;
+import org.wso2.identity.webhook.common.event.handler.api.model.EventData;
+import org.wso2.identity.webhook.wso2.event.handler.internal.component.WSO2EventHookHandlerDataHolder;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleCreatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleDeletedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleGroupsUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleIdpGroupsUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RolePermissionsUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleMetaUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.GroupEntry;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.UserEntry;
+import org.wso2.identity.webhook.wso2.event.handler.internal.model.WSO2RoleUsersUpdatedEventPayload;
+import org.wso2.identity.webhook.wso2.event.handler.internal.util.CommonTestUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.identity.webhook.wso2.event.handler.internal.util.TestUtils.closeMockedServiceURLBuilder;
+import static org.wso2.identity.webhook.wso2.event.handler.internal.util.TestUtils.mockServiceURLBuilder;
+
+/**
+ * Unit tests for {@link WSO2RoleManagementEventPayloadBuilder}.
+ */
+public class WSO2RoleManagementEventPayloadBuilderTest {
+
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final int TENANT_ID = -1234;
+    private static final String ROLE_ID = "test-role-id-001";
+    private static final String ROLE_NAME = "TestRole";
+    private static final String AUDIENCE_TYPE = "application";
+    private static final String AUDIENCE_ID = "app-001";
+    private static final String AUDIENCE_NAME = "TestApp";
+    private static final String USER_ID_1 = "user-001";
+    private static final String USER_ID_2 = "user-002";
+    private static final String USERNAME_1 = "alice";
+    private static final String USERNAME_2 = "agent-01";
+    private static final String AGENT_NAME_2 = "Support Agent";
+    private static final String USER_STORE_1 = "PRIMARY";
+    private static final String USER_STORE_2 = "AGENT";
+    private static final String USERNAME_CLAIM_URI = "http://wso2.org/claims/username";
+    private static final String AGENT_NAME_CLAIM_URI = "http://wso2.org/claims/agent/Name";
+    private static final String GROUP_ID_1 = "group-001";
+    private static final String GROUP_NAME_1 = "dev-team";
+    private static final String GROUP_USER_STORE = "PRIMARY";
+    private static final String IDP_ID_1 = "idp-resource-001";
+    private static final String IDP_NAME_1 = "SampleIdP";
+
+    @Mock
+    private RoleManagementService roleManagementService;
+    @Mock
+    private RealmService realmService;
+    @Mock
+    private AbstractUserStoreManager userStoreManager;
+    @Mock
+    private IdpManager idpManager;
+
+    private MockedStatic<IdentityTenantUtil> mockedIdentityTenantUtil;
+    private WSO2RoleManagementEventPayloadBuilder builder;
+
+    @BeforeClass
+    void setUp() throws Exception {
+
+        MockitoAnnotations.openMocks(this);
+
+        RoleBasicInfo roleBasicInfo = new RoleBasicInfo(ROLE_ID, ROLE_NAME);
+        roleBasicInfo.setAudience(AUDIENCE_TYPE);
+        roleBasicInfo.setAudienceId(AUDIENCE_ID);
+        roleBasicInfo.setAudienceName(AUDIENCE_NAME);
+        when(roleManagementService.getRoleBasicInfoById(anyString(), anyString())).thenReturn(roleBasicInfo);
+        WSO2EventHookHandlerDataHolder.getInstance().setRoleManagementService(roleManagementService);
+
+        // Wire RealmService → UserStoreManager for username/groupName enrichment.
+        UserRealm userRealm = mock(UserRealm.class);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
+        // USER_ID_1 → normal PRIMARY user (username claim only).
+        // USER_ID_2 → AGENT user-store user (username + agent Name claim).
+        when(userStoreManager.getUserNameFromUserID(USER_ID_1)).thenReturn(USERNAME_1);
+        when(userStoreManager.getUserNameFromUserID(USER_ID_2)).thenReturn(USER_STORE_2 + "/" + USERNAME_2);
+        Map<String, String> user1Claims = new HashMap<>();
+        user1Claims.put(USERNAME_CLAIM_URI, USERNAME_1);
+        when(userStoreManager.getUserClaimValuesWithID(
+                USER_ID_1, new String[]{USERNAME_CLAIM_URI, AGENT_NAME_CLAIM_URI}, null))
+                .thenReturn(user1Claims);
+        Map<String, String> user2Claims = new HashMap<>();
+        user2Claims.put(USERNAME_CLAIM_URI, USERNAME_2);
+        user2Claims.put(AGENT_NAME_CLAIM_URI, AGENT_NAME_2);
+        when(userStoreManager.getUserClaimValuesWithID(
+                USER_ID_2, new String[]{USERNAME_CLAIM_URI, AGENT_NAME_CLAIM_URI}, null))
+                .thenReturn(user2Claims);
+        Group group1 = mock(Group.class);
+        when(group1.getGroupName()).thenReturn(GROUP_NAME_1);
+        when(group1.getUserStoreDomain()).thenReturn(GROUP_USER_STORE);
+        when(userStoreManager.getGroup(GROUP_ID_1, null)).thenReturn(group1);
+        WSO2EventHookHandlerDataHolder.getInstance().setRealmService(realmService);
+
+        // Wire IdpManager for idpName enrichment.
+        IdentityProvider idp = mock(IdentityProvider.class);
+        when(idp.getIdentityProviderName()).thenReturn(IDP_NAME_1);
+        when(idpManager.getIdPByResourceId(IDP_ID_1, TENANT_DOMAIN, true)).thenReturn(idp);
+        WSO2EventHookHandlerDataHolder.getInstance().setIdpManager(idpManager);
+
+        mockServiceURLBuilder();
+
+        // IdentityTenantUtil mock for TENANT_DOMAIN used in getAbstractUserStoreManager.
+        mockedIdentityTenantUtil = mockStatic(IdentityTenantUtil.class);
+        mockedIdentityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+
+        CommonTestUtils.initPrivilegedCarbonContext();
+
+        Flow flow = new Flow.Builder()
+                .name(Flow.Name.USER_GROUP_UPDATE)
+                .initiatingPersona(Flow.InitiatingPersona.ADMIN)
+                .build();
+        IdentityContext.getThreadLocalIdentityContext().enterFlow(flow);
+
+        if (IdentityContext.getThreadLocalIdentityContext().getRootOrganization() == null) {
+            RootOrganization rootOrganization = new RootOrganization.Builder()
+                    .associatedTenantDomain(TENANT_DOMAIN)
+                    .associatedTenantId(TENANT_ID)
+                    .build();
+            IdentityContext.getThreadLocalIdentityContext().setRootOrganization(rootOrganization);
+        }
+
+        if (IdentityContext.getThreadLocalIdentityContext().getOrganization() == null) {
+            Organization organization = new Organization.Builder()
+                    .id("org-001")
+                    .name("Test Organization")
+                    .organizationHandle(TENANT_DOMAIN)
+                    .depth(0)
+                    .build();
+            IdentityContext.getThreadLocalIdentityContext().setOrganization(organization);
+        }
+
+        builder = new WSO2RoleManagementEventPayloadBuilder();
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        closeMockedServiceURLBuilder();
+        if (mockedIdentityTenantUtil != null) {
+            mockedIdentityTenantUtil.close();
+        }
+        IdentityContext.getThreadLocalIdentityContext().exitFlow();
+    }
+
+    @Test
+    public void testGetEventSchemaType() {
+
+        assertEquals(builder.getEventSchemaType(), Constants.EventSchema.WSO2);
+    }
+
+    @Test
+    public void testBuildRoleCreatedEventReturnsCorrectType() throws IdentityEventException {
+
+        EventData eventData = mock(EventData.class);
+        when(eventData.getEventParams()).thenReturn(buildRoleCreatedProperties());
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleCreatedEvent(eventData);
+
+        assertNotNull(payload);
+        assertTrue(payload instanceof WSO2RoleCreatedEventPayload);
+
+        WSO2RoleCreatedEventPayload created = (WSO2RoleCreatedEventPayload) payload;
+        assertNotNull(created.getRole());
+        assertEquals(created.getRole().getId(), ROLE_ID);
+    }
+
+    @Test
+    public void testBuildRoleCreatedEventWithUsersAndGroups() throws IdentityEventException {
+
+        Map<String, Object> props = buildRoleCreatedProperties();
+        props.put(IdentityEventConstants.EventProperty.USER_LIST, Arrays.asList(USER_ID_1, USER_ID_2));
+        props.put(IdentityEventConstants.EventProperty.GROUP_LIST, Arrays.asList(GROUP_ID_1));
+
+        EventData eventData = mock(EventData.class);
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleCreatedEvent(eventData);
+
+        WSO2RoleCreatedEventPayload created = (WSO2RoleCreatedEventPayload) payload;
+        assertNotNull(created.getRole().getUsers());
+        assertEquals(created.getRole().getUsers().size(), 2);
+        UserEntry user1 = created.getRole().getUsers().get(0);
+        assertEquals(user1.getId(), USER_ID_1);
+        assertEquals(user1.getUserStoreDomain(), USER_STORE_1);
+        assertNotNull(user1.getRef());
+        assertUsernameClaim(user1, USERNAME_1);
+        assertNoAgentNameClaim(user1);
+        UserEntry user2 = created.getRole().getUsers().get(1);
+        assertEquals(user2.getId(), USER_ID_2);
+        assertEquals(user2.getUserStoreDomain(), USER_STORE_2);
+        assertNotNull(user2.getRef());
+        assertUsernameClaim(user2, USERNAME_2);
+        assertAgentNameClaim(user2, AGENT_NAME_2);
+        assertNotNull(created.getRole().getGroups());
+        assertEquals(created.getRole().getGroups().size(), 1);
+        GroupEntry group1 = created.getRole().getGroups().get(0);
+        assertEquals(group1.getId(), GROUP_ID_1);
+        assertEquals(group1.getGroupName(), GROUP_NAME_1);
+        assertEquals(group1.getUserStoreDomain(), GROUP_USER_STORE);
+    }
+
+    @Test
+    public void testBuildRoleCreatedEventWithPermissions() throws IdentityEventException {
+
+        Permission perm = new Permission("read", "Read permission");
+        Map<String, Object> props = buildRoleCreatedProperties();
+        props.put(IdentityEventConstants.EventProperty.PERMISSIONS, Collections.singletonList(perm));
+
+        EventData eventData = mock(EventData.class);
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleCreatedEvent(eventData);
+
+        WSO2RoleCreatedEventPayload created = (WSO2RoleCreatedEventPayload) payload;
+        assertNotNull(created.getRole().getPermissions());
+        assertEquals(created.getRole().getPermissions().size(), 1);
+        assertEquals(created.getRole().getPermissions().get(0), "read");
+    }
+
+    @Test
+    public void testBuildRoleMetaUpdatedEventReturnsCorrectType() throws IdentityEventException {
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.NEW_ROLE_NAME, "UpdatedRoleName");
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleMetaUpdatedEvent(eventData);
+
+        assertNotNull(payload);
+        assertTrue(payload instanceof WSO2RoleMetaUpdatedEventPayload);
+
+        WSO2RoleMetaUpdatedEventPayload updated = (WSO2RoleMetaUpdatedEventPayload) payload;
+        assertNotNull(updated.getRole());
+        assertEquals(updated.getRole().getId(), ROLE_ID);
+        assertEquals(updated.getRole().getName(), "UpdatedRoleName");
+    }
+
+    @Test
+    public void testBuildRoleDeletedEventReturnsCorrectType() throws IdentityEventException {
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleDeletedEvent(eventData);
+
+        assertNotNull(payload);
+        assertTrue(payload instanceof WSO2RoleDeletedEventPayload);
+
+        WSO2RoleDeletedEventPayload deleted = (WSO2RoleDeletedEventPayload) payload;
+        assertNotNull(deleted.getRole());
+        assertEquals(deleted.getRole().getId(), ROLE_ID);
+    }
+
+    @Test
+    public void testBuildRoleUsersUpdatedEventReturnsCorrectType() throws IdentityEventException {
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.NEW_USER_ID_LIST, Arrays.asList(USER_ID_1));
+        props.put(IdentityEventConstants.EventProperty.DELETE_USER_ID_LIST, Arrays.asList(USER_ID_2));
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleUsersUpdatedEvent(eventData);
+
+        assertNotNull(payload);
+        assertTrue(payload instanceof WSO2RoleUsersUpdatedEventPayload);
+
+        WSO2RoleUsersUpdatedEventPayload userList = (WSO2RoleUsersUpdatedEventPayload) payload;
+        assertNotNull(userList.getRole());
+        assertNotNull(userList.getRole().getAddedUsers());
+        assertEquals(userList.getRole().getAddedUsers().size(), 1);
+        UserEntry addedUser = userList.getRole().getAddedUsers().get(0);
+        assertEquals(addedUser.getId(), USER_ID_1);
+        assertEquals(addedUser.getUserStoreDomain(), USER_STORE_1);
+        assertNotNull(addedUser.getRef());
+        assertUsernameClaim(addedUser, USERNAME_1);
+        assertNoAgentNameClaim(addedUser);
+        assertNotNull(userList.getRole().getRemovedUsers());
+        assertEquals(userList.getRole().getRemovedUsers().size(), 1);
+        UserEntry removedUser = userList.getRole().getRemovedUsers().get(0);
+        assertEquals(removedUser.getId(), USER_ID_2);
+        assertEquals(removedUser.getUserStoreDomain(), USER_STORE_2);
+        assertNotNull(removedUser.getRef());
+        assertUsernameClaim(removedUser, USERNAME_2);
+        assertAgentNameClaim(removedUser, AGENT_NAME_2);
+    }
+
+    @Test
+    public void testBuildRoleGroupsUpdatedEventReturnsCorrectType() throws IdentityEventException {
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.NEW_GROUP_ID_LIST, Arrays.asList(GROUP_ID_1));
+        props.put(IdentityEventConstants.EventProperty.DELETE_GROUP_ID_LIST, Collections.emptyList());
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleGroupsUpdatedEvent(eventData);
+
+        assertNotNull(payload);
+        assertTrue(payload instanceof WSO2RoleGroupsUpdatedEventPayload);
+
+        WSO2RoleGroupsUpdatedEventPayload groupList = (WSO2RoleGroupsUpdatedEventPayload) payload;
+        assertNotNull(groupList.getRole());
+        assertNotNull(groupList.getRole().getAddedGroups());
+        assertEquals(groupList.getRole().getAddedGroups().size(), 1);
+        GroupEntry addedGroup = groupList.getRole().getAddedGroups().get(0);
+        assertEquals(addedGroup.getId(), GROUP_ID_1);
+        assertEquals(addedGroup.getGroupName(), GROUP_NAME_1);
+        assertEquals(addedGroup.getUserStoreDomain(), GROUP_USER_STORE);
+    }
+
+    @Test
+    public void testBuildRoleIdpGroupsUpdatedEventResolvesIdpName() throws IdentityEventException {
+
+        IdpGroup idpGroup = new IdpGroup("idp-group-001", IDP_ID_1);
+        idpGroup.setGroupName("IdpGroupOne");
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.NEW_GROUP_ID_LIST,
+                Collections.singletonList(idpGroup));
+        props.put(IdentityEventConstants.EventProperty.DELETE_GROUP_ID_LIST, Collections.emptyList());
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleIdpGroupsUpdatedEvent(eventData);
+
+        assertNotNull(payload);
+        assertTrue(payload instanceof WSO2RoleIdpGroupsUpdatedEventPayload);
+
+        WSO2RoleIdpGroupsUpdatedEventPayload idpGroupList = (WSO2RoleIdpGroupsUpdatedEventPayload) payload;
+        assertNotNull(idpGroupList.getRole());
+        assertNotNull(idpGroupList.getRole().getAddedIdpGroups());
+        assertEquals(idpGroupList.getRole().getAddedIdpGroups().size(), 1);
+
+        WSO2RoleIdpGroupsUpdatedEventPayload.IdpGroupEntry entry =
+                idpGroupList.getRole().getAddedIdpGroups().get(0);
+        assertEquals(entry.getGroupId(), "idp-group-001");
+        assertEquals(entry.getIdpId(), IDP_ID_1);
+        assertEquals(entry.getIdpName(), IDP_NAME_1);
+    }
+
+    @Test
+    public void testBuildRoleIdpGroupsUpdatedEventPreservesExistingIdpName() throws IdentityEventException {
+
+        IdpGroup idpGroup = new IdpGroup("idp-group-002", "idp-resource-002");
+        idpGroup.setGroupName("IdpGroupTwo");
+        idpGroup.setIdpName("ExistingIdP");
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.NEW_GROUP_ID_LIST,
+                Collections.singletonList(idpGroup));
+        props.put(IdentityEventConstants.EventProperty.DELETE_GROUP_ID_LIST, Collections.emptyList());
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleIdpGroupsUpdatedEvent(eventData);
+
+        WSO2RoleIdpGroupsUpdatedEventPayload idpGroupList = (WSO2RoleIdpGroupsUpdatedEventPayload) payload;
+        assertEquals(idpGroupList.getRole().getAddedIdpGroups().get(0).getIdpName(), "ExistingIdP");
+    }
+
+    @Test
+    public void testBuildRolePermissionsUpdatedEventReturnsCorrectType() throws IdentityEventException {
+
+        Permission perm = new Permission("write", "Write permission");
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.ADDED_PERMISSIONS,
+                Collections.singletonList(perm));
+        props.put(IdentityEventConstants.EventProperty.DELETED_PERMISSIONS, Collections.emptyList());
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRolePermissionsUpdatedEvent(eventData);
+
+        assertNotNull(payload);
+        assertTrue(payload instanceof WSO2RolePermissionsUpdatedEventPayload);
+
+        WSO2RolePermissionsUpdatedEventPayload permsPayload = (WSO2RolePermissionsUpdatedEventPayload) payload;
+        assertNotNull(permsPayload.getRole());
+        assertNotNull(permsPayload.getRole().getAddedPermissions());
+        assertEquals(permsPayload.getRole().getAddedPermissions().size(), 1);
+        assertEquals(permsPayload.getRole().getAddedPermissions().get(0), "write");
+    }
+
+    @Test
+    public void testBuildRoleCreatedEventWithNoEnrichmentWhenServiceUnavailable() throws IdentityEventException {
+
+        WSO2EventHookHandlerDataHolder.getInstance().setRoleManagementService(null);
+
+        EventData eventData = mock(EventData.class);
+        when(eventData.getEventParams()).thenReturn(buildRoleCreatedProperties());
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleCreatedEvent(eventData);
+
+        assertNotNull(payload);
+        assertTrue(payload instanceof WSO2RoleCreatedEventPayload);
+
+        // Restore
+        WSO2EventHookHandlerDataHolder.getInstance().setRoleManagementService(roleManagementService);
+    }
+
+    // ---- helpers ----
+
+    private Map<String, Object> buildRoleCreatedProperties() {
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.AUDIENCE, AUDIENCE_TYPE);
+        props.put(IdentityEventConstants.EventProperty.AUDIENCE_ID, AUDIENCE_ID);
+        return props;
+    }
+
+    private void assertUsernameClaim(UserEntry entry, String expectedUsername) {
+
+        assertNotNull(entry.getClaims());
+        Object value = entry.getClaims().stream()
+                .filter(c -> USERNAME_CLAIM_URI.equals(c.getUri()))
+                .map(c -> c.getValue())
+                .findFirst()
+                .orElse(null);
+        assertEquals(value, expectedUsername);
+    }
+
+    private void assertAgentNameClaim(UserEntry entry, String expectedAgentName) {
+
+        assertNotNull(entry.getClaims());
+        Object value = entry.getClaims().stream()
+                .filter(c -> AGENT_NAME_CLAIM_URI.equals(c.getUri()))
+                .map(c -> c.getValue())
+                .findFirst()
+                .orElse(null);
+        assertEquals(value, expectedAgentName);
+    }
+
+    private void assertNoAgentNameClaim(UserEntry entry) {
+
+        if (entry.getClaims() == null) {
+            return;
+        }
+        boolean hasAgentName = entry.getClaims().stream()
+                .anyMatch(c -> AGENT_NAME_CLAIM_URI.equals(c.getUri()));
+        assertEquals(hasAgentName, false);
+    }
+}

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilderTest.java
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/java/org/wso2/identity/webhook/wso2/event/handler/api/builder/WSO2RoleManagementEventPayloadBuilderTest.java
@@ -85,16 +85,22 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
     private static final String AUDIENCE_NAME = "TestApp";
     private static final String USER_ID_1 = "user-001";
     private static final String USER_ID_2 = "user-002";
+    private static final String USER_ID_3 = "user-003";
     private static final String USERNAME_1 = "alice";
     private static final String USERNAME_2 = "agent-01";
+    private static final String USERNAME_3 = "bob";
     private static final String AGENT_NAME_2 = "Support Agent";
     private static final String USER_STORE_1 = "PRIMARY";
     private static final String USER_STORE_2 = "AGENT";
+    private static final String USER_STORE_3 = "SECONDARY";
     private static final String USERNAME_CLAIM_URI = "http://wso2.org/claims/username";
     private static final String AGENT_NAME_CLAIM_URI = "http://wso2.org/claims/agent/Name";
     private static final String GROUP_ID_1 = "group-001";
     private static final String GROUP_NAME_1 = "dev-team";
     private static final String GROUP_USER_STORE = "PRIMARY";
+    private static final String GROUP_ID_2 = "group-002";
+    private static final String GROUP_NAME_2 = "qa-team";
+    private static final String GROUP_USER_STORE_2 = "SECONDARY";
     private static final String IDP_ID_1 = "idp-resource-001";
     private static final String IDP_NAME_1 = "SampleIdP";
 
@@ -141,10 +147,23 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
         when(userStoreManager.getUserClaimValuesWithID(
                 USER_ID_2, new String[]{USERNAME_CLAIM_URI, AGENT_NAME_CLAIM_URI}, null))
                 .thenReturn(user2Claims);
+        // USER_ID_3 → username claim already carries the user-store domain prefix; the domain
+        // must be cropped from it. getUserNameFromUserID is intentionally left unstubbed
+        // (returns null) to prove the separate domain lookup is skipped.
+        Map<String, String> user3Claims = new HashMap<>();
+        user3Claims.put(USERNAME_CLAIM_URI, USER_STORE_3 + "/" + USERNAME_3);
+        when(userStoreManager.getUserClaimValuesWithID(
+                USER_ID_3, new String[]{USERNAME_CLAIM_URI, AGENT_NAME_CLAIM_URI}, null))
+                .thenReturn(user3Claims);
         Group group1 = mock(Group.class);
         when(group1.getGroupName()).thenReturn(GROUP_NAME_1);
         when(group1.getUserStoreDomain()).thenReturn(GROUP_USER_STORE);
         when(userStoreManager.getGroup(GROUP_ID_1, null)).thenReturn(group1);
+        // GROUP_ID_2 → name already carries the user-store domain prefix.
+        Group group2 = mock(Group.class);
+        when(group2.getGroupName()).thenReturn(GROUP_USER_STORE_2 + "/" + GROUP_NAME_2);
+        when(group2.getUserStoreDomain()).thenReturn("");
+        when(userStoreManager.getGroup(GROUP_ID_2, null)).thenReturn(group2);
         WSO2EventHookHandlerDataHolder.getInstance().setRealmService(realmService);
 
         // Wire IdpManager for idpName enrichment.
@@ -352,6 +371,28 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
     }
 
     @Test
+    public void testBuildRoleUsersUpdatedEventCropsUserStoreFromUsername() throws IdentityEventException {
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.NEW_USER_ID_LIST, Arrays.asList(USER_ID_3));
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleUsersUpdatedEvent(eventData);
+
+        WSO2RoleUsersUpdatedEventPayload userList = (WSO2RoleUsersUpdatedEventPayload) payload;
+        assertNotNull(userList.getRole().getAddedUsers());
+        assertEquals(userList.getRole().getAddedUsers().size(), 1);
+        UserEntry addedUser = userList.getRole().getAddedUsers().get(0);
+        assertEquals(addedUser.getId(), USER_ID_3);
+        // Domain cropped from the prefixed username; plain username and cropped domain reported separately.
+        assertEquals(addedUser.getUserStoreDomain(), USER_STORE_3);
+        assertUsernameClaim(addedUser, USERNAME_3);
+    }
+
+    @Test
     public void testBuildRoleGroupsUpdatedEventReturnsCorrectType() throws IdentityEventException {
 
         EventData eventData = mock(EventData.class);
@@ -375,6 +416,29 @@ public class WSO2RoleManagementEventPayloadBuilderTest {
         assertEquals(addedGroup.getId(), GROUP_ID_1);
         assertEquals(addedGroup.getGroupName(), GROUP_NAME_1);
         assertEquals(addedGroup.getUserStoreDomain(), GROUP_USER_STORE);
+    }
+
+    @Test
+    public void testBuildRoleGroupsUpdatedEventCropsUserStoreFromGroupName() throws IdentityEventException {
+
+        EventData eventData = mock(EventData.class);
+        Map<String, Object> props = new HashMap<>();
+        props.put(IdentityEventConstants.EventProperty.ROLE_ID, ROLE_ID);
+        props.put(IdentityEventConstants.EventProperty.NEW_GROUP_ID_LIST, Arrays.asList(GROUP_ID_2));
+        props.put(IdentityEventConstants.EventProperty.DELETE_GROUP_ID_LIST, Collections.emptyList());
+        when(eventData.getEventParams()).thenReturn(props);
+        when(eventData.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+
+        EventPayload payload = builder.buildRoleGroupsUpdatedEvent(eventData);
+
+        WSO2RoleGroupsUpdatedEventPayload groupList = (WSO2RoleGroupsUpdatedEventPayload) payload;
+        assertNotNull(groupList.getRole().getAddedGroups());
+        assertEquals(groupList.getRole().getAddedGroups().size(), 1);
+        GroupEntry addedGroup = groupList.getRole().getAddedGroups().get(0);
+        assertEquals(addedGroup.getId(), GROUP_ID_2);
+        // Domain cropped from the prefixed name; plain name and cropped domain reported separately.
+        assertEquals(addedGroup.getGroupName(), GROUP_NAME_2);
+        assertEquals(addedGroup.getUserStoreDomain(), GROUP_USER_STORE_2);
     }
 
     @Test

--- a/components/org.wso2.identity.webhook.wso2.event.handler/src/test/resources/testng.xml
+++ b/components/org.wso2.identity.webhook.wso2.event.handler/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
             <class name="org.wso2.identity.webhook.wso2.event.handler.api.builder.WSO2CredentialEventPayloadBuilderTest"/>
             <class name="org.wso2.identity.webhook.wso2.event.handler.api.builder.WSO2RegistrationEventPayloadBuilderTest"/>
             <class name="org.wso2.identity.webhook.wso2.event.handler.internal.service.impl.WSO2EventProfileManagerTest"/>
+            <class name="org.wso2.identity.webhook.wso2.event.handler.api.builder.WSO2RoleManagementEventPayloadBuilderTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,16 @@
                 <artifactId>org.wso2.carbon.identity.compatibility.settings.core</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.role.v2.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.idp.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
             <!--Test dependencies-->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.11.94</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.152</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.20.90, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose

Adds WSO2 webhook event payload support for the V2 role lifecycle and enriches role-member payloads.

## Changes

- **Role lifecycle events** — build payloads for role created / meta-updated / deleted / users-updated / groups-updated / idp-groups-updated / permissions-updated.
- **Role deleted event** — publish the role `name` alongside the `id` (no enrichment, since the role is already gone).
- **Group name enrichment** — when a role-member group name already carries the user-store domain prefix (e.g. `PRIMARY/dev-team`), crop it off and report the domain separately instead of doing a second lookup.
- **Username enrichment** — apply the same cropping to the username claim (e.g. `SECONDARY/bob` → username `bob`, domain `SECONDARY`); when the domain is present in the name, the separate user-store lookup is skipped.
- **Misc** — drop the `ref` field from `UserEntry`; fix claims not updating with empty values; bump `carbon.identity.framework.version`.

## Testing

- Unit tests added/updated in `WSO2RoleManagementEventPayloadBuilderTest` covering each event type, the role-name-on-delete case, and the group-name / username user-store cropping cases.
- Full `mvn clean install` passes (all modules green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)